### PR TITLE
Adding views for courses/admin/email.

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -2,25 +2,28 @@
 
 ## Arrow Functions
 
-This projet heavily prefers the use of the `function` keyword over the use of 
-[arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) 
-in most cases.
-Arrow functions may be used for one line callbacks within methods such as `Array.map()` and `Array.filter()`.
-If the right hand side of the arrow function is more than a single expression,
+This projet heavily prefers the use of the `function` keyword over the use of
+[arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
+Arrow functions may be used for one line callbacks.
+If the RHS of the arrow function is more than a single expression,
 use the `function` keyword instead.
 
-
-Ensure that both the righthand side and lefthand side of the arrow wrapped in parentheses.
+Both the RHS and LHS of the arrow must be wrapped in parentheses.
 For example:
-
 ```javascript
-// Good
+/* Good */
+// One line, parentheses on both sides.
 numbers.map((number) => (number * 2));
 
-// Bad
+/* Bad */
+// Missing parentheses on both sides.
 numbers.map(number => number * 2);
-numbers.map(number => {
-		return number * 2;
-});
+
+// Missing parentheses on RHS.
 numbers.map((number) => number * 2);
+
+// Using multiple lines.
+numbers.map((number) => {
+    return (number * 2);
+});
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,10 +1,18 @@
 # Development Notes
 
 ## Arrow Functions
-This projet heavily prefers the use of the `function` keyword over the use of arrow functions in most cases.
-Arrow functions may be used in simple callbacks in functional functions such as `map` or `filter` and should not be more than one line long.
-If the right hand side of the arrow function is more than a single expression, use the `function` keyword instead.
-Ensure that both the righthand side and lefthand side of the arrow wrapped in parentheses. For example:
+
+This projet heavily prefers the use of the `function` keyword over the use of 
+[arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) 
+in most cases.
+Arrow functions may be used for one line callbacks within methods such as `Array.map()` and `Array.filter()`.
+If the right hand side of the arrow function is more than a single expression,
+use the `function` keyword instead.
+
+
+Ensure that both the righthand side and lefthand side of the arrow wrapped in parentheses.
+For example:
+
 ```javascript
 // Good
 numbers.map((number) => (number * 2));

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,25 +4,23 @@
 
 This projet heavily prefers the use of the `function` keyword over the use of
 [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
-Arrow functions may be used for one line callbacks.
+Arrow functions may only be used for one line callbacks.
 If the RHS of the arrow function is more than a single expression,
 use the `function` keyword instead.
-
 Both the RHS and LHS of the arrow must be wrapped in parentheses.
-For example:
+
+Consider the following cases:
 ```javascript
-/* Good */
-// One line, parentheses on both sides.
+// Good: One line, parentheses on both sides.
 numbers.map((number) => (number * 2));
 
-/* Bad */
-// Missing parentheses on both sides.
+// Bad: Missing parentheses on both sides.
 numbers.map(number => number * 2);
 
-// Missing parentheses on RHS.
+// Bad: Missing parentheses on RHS.
 numbers.map((number) => number * 2);
 
-// Using multiple lines.
+// Bad: Using multiple lines.
 numbers.map((number) => {
     return (number * 2);
 });

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,18 @@
+# Development Notes
+
+## Arrow Functions
+This projet heavily prefers the use of the `function` keyword over the use of arrow functions in most cases.
+Arrow functions may be used in simple callbacks in functional functions such as `map` or `filter` and should not be more than one line long.
+If the right hand side of the arrow function is more than a single expression, use the `function` keyword instead.
+Ensure that both the righthand side and lefthand side of the arrow wrapped in parentheses. For example:
+```javascript
+// Good
+numbers.map((number) => (number * 2));
+
+// Bad
+numbers.map(number => number * 2);
+numbers.map(number => {
+		return number * 2;
+});
+numbers.map((number) => number * 2);
+```

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -530,13 +530,15 @@ fieldset {
     text-decoration: none;
 }
 
-.endpoint-page {
+.endpoint-page,
+.email-page {
     display: flex;
     flex-direction: row;
     justify-content: center;
 }
 
-.endpoint-content {
+.endpoint-content,
+.email-content {
     display: flex;
     flex-direction: column;
     align-content: center;
@@ -586,11 +588,21 @@ fieldset {
     margin-bottom: 0.5em;
 }
 
-.user-input-fields label {
+.user-input-fields fieldset > div.checkbox-field {
+    flex-direction: row;
+    align-items: center;
+}
+
+.user-input-fields .input-field label {
     margin-bottom: 0.5em;
 }
 
-.endpoint-content > div {
+.user-input-fields .checkbox-field label {
+    margin-left: 0.5em;
+}
+
+.endpoint-content > div,
+.email-content > div {
     display: flex;
     flex-direction: column;
     align-content: center;

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -158,7 +158,8 @@ a {
 
 button,
 input,
-select {
+select,
+textarea {
     background-color: var(--color-bg-secondary);
     color: var(--color-text-secondary);
     border-width: medium;
@@ -436,7 +437,8 @@ fieldset {
     max-width: 95vw;
 }
 
-.endpoint-area {
+.endpoint-area,
+.email-area {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
@@ -451,7 +453,8 @@ fieldset {
     display: none;
 }
 
-.endpoint-area fieldset {
+.endpoint-area fieldset,
+.email-area fieldset {
     display: flex;
     flex-direction: column;
     align-self: stretch;
@@ -466,16 +469,19 @@ fieldset {
     box-shadow: 2px 2px 1px var(--color-bg-shadow);
 }
 
-.endpoint-area .input-field {
+.endpoint-area .input-field,
+.email-area .input-field {
     display: flex;
     flex-direction: column;
 }
 
-.endpoint-area label {
+.endpoint-area label,
+.email-area label {
     margin-bottom: 0.25em;
 }
 
-.endpoint-area input {
+.endpoint-area input,
+.email-area input {
     padding: 0.5em;
 }
 

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -485,6 +485,10 @@ fieldset {
     padding: 0.5em;
 }
 
+.email-area textarea {
+    resize: none;
+}
+
 .results-area .code {
     display: flex;
     flex-direction: column;

--- a/site/js/modules/autograder/base.js
+++ b/site/js/modules/autograder/base.js
@@ -1,5 +1,6 @@
 import * as Assignments from './assignments.js'
 import * as Core from './core.js'
+import * as Course from './course.js'
 import * as Server from './server.js'
 import * as Submissions from './submissions.js'
 import * as Users from './users.js'
@@ -12,6 +13,7 @@ let clearCredentials = Core.clearCredentials;
 
 export {
     Assignments,
+    Course,
     Server,
     Submissions,
     Users,

--- a/site/js/modules/autograder/base.js
+++ b/site/js/modules/autograder/base.js
@@ -1,9 +1,9 @@
-import * as Assignments from './assignments.js'
-import * as Core from './core.js'
-import * as Course from './course.js'
-import * as Server from './server.js'
-import * as Submissions from './submissions.js'
-import * as Users from './users.js'
+import * as Assignments from './assignments.js';
+import * as Core from './core.js';
+import * as Course from './course.js';
+import * as Server from './server.js';
+import * as Submissions from './submissions.js';
+import * as Users from './users.js';
 
 // API functions to interact with an autograder server.
 
@@ -21,4 +21,4 @@ export {
     hasCredentials,
     setCredentials,
     clearCredentials,
-}
+};

--- a/site/js/modules/autograder/course.js
+++ b/site/js/modules/autograder/course.js
@@ -1,6 +1,6 @@
 import * as Core from './core.js';
 
-function emailUsers(params) {
+function email(params) {
     return Core.sendRequest({
         endpoint: 'courses/admin/email',
         payload: params,
@@ -8,5 +8,5 @@ function emailUsers(params) {
 }
 
 export {
-    emailUsers,
+    email,
 };

--- a/site/js/modules/autograder/course.js
+++ b/site/js/modules/autograder/course.js
@@ -1,0 +1,12 @@
+import * as Core from './core.js';
+
+function emailUsers(params) {
+    return Core.sendRequest({
+        endpoint: 'courses/admin/email',
+        payload: params,
+    });
+}
+
+export {
+    emailUsers,
+};

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -2,7 +2,7 @@ import * as Autograder from '../autograder/base.js';
 import * as Render from './render.js';
 import * as Routing from './routing.js';
 
-const recipientDocsLink = "https://github.com/edulinq/autograder-server/blob/main/docs/types.md#course-user-reference-courseuserreference";
+const EMAIL_RECIPIENT_DOCS_LINK = "https://github.com/edulinq/autograder-server/blob/main/docs/types.md#course-user-reference-courseuserreference";
 
 function init() {
     let requirements = {course: true};
@@ -72,8 +72,8 @@ function handlerEmail(path, params, context, container) {
                 <div class="description">
                     <p>
                         Separate recipient values with commas.
-                        For valid recipient values reference 
-                            <a href=${recipientDocsLink} target="_blank">documentation</a>.
+                        For valid recipient values reference this 
+                        <a href=${EMAIL_RECIPIENT_DOCS_LINK} target="_blank">documentation</a>.
                     </p>
                 </div>
                 <div class="user-input-fields secondary-color drop-shadow">
@@ -131,12 +131,12 @@ function handlerEmail(path, params, context, container) {
         if (args[Routing.PARAM_EMAIL_TO].length === 0 &&
                 args[Routing.PARAM_EMAIL_CC].length === 0 &&
                 args[Routing.PARAM_EMAIL_BCC].length === 0) {
-            renderResult('<p>Please specify at least one recipient.</p>');
+            renderResult('<p>Specify at least one recipient.</p>');
             return;
         }
 
         if (args[Routing.PARAM_EMAIL_SUBJECT].length === 0) {
-            renderResult('<p>Please include a subject.</p>');
+            renderResult('<p>Include a subject.</p>');
             return;
         }
 
@@ -144,12 +144,7 @@ function handlerEmail(path, params, context, container) {
             .then(function(result) {
                 renderResult(`
                     <p>Email sent successfully.</p>
-                    <p><strong>Recipients</strong> (total ${result[Routing.PARAM_EMAIL_TO].length})</p>
-                    <p>${result[Routing.PARAM_EMAIL_TO].join(', ')}</p>
-                    <p><strong>CC-ed Recipients</strong> (total ${result[Routing.PARAM_EMAIL_CC].length})</p>
-                    <p>${result[Routing.PARAM_EMAIL_CC].join(', ')}</p>
-                    <p><strong>BCC-ed Recipients</strong> (total ${result[Routing.PARAM_EMAIL_BCC].length})</p>
-                    <p>${result[Routing.PARAM_EMAIL_BCC].join(', ')}</p>
+                    <pre><code data-lang="json">${JSON.stringify(result, null, 4)}</code></pre>
                 `);
             })
             .catch(function(message) {

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -64,43 +64,49 @@ function handlerUsers(path, params, context, container) {
     Routing.setTitle(course.id, titleHTML);
 
     container.innerHTML = `
-        <h2>Email Users</h2>
-        <div class="email-area">
-            <p>Sumbitting this form will send an email to all users enrolled in the course.</p>
-            <p>Please separate email addresses with commas.</p>
-            <fieldset>
-                <div class="input-field">
-                    <label for="email-to">To</label>
-                    <input type="text" id="email-to" name="to" placeholder="Recipients" required />
+        <div class="email-page">
+            <div class="email-content">
+                <h2>Email Users</h2>
+                <div class="description">
+                    <p>Sumbitting this form will send an email to all users enrolled in the course.</p>
+                    <p>Please separate email addresses with commas.</p>
                 </div>
-                <div class="input-field">
-                    <label for="email-cc">CC</label>
-                    <input type="text" id="email-cc" name="cc" placeholder="CC" />
+                <div class="user-input-fields secondary-color drop-shadow">
+                    <fieldset>
+                        <div class="input-field">
+                            <label for="email-to">To</label>
+                            <input type="text" id="email-to" name="to" placeholder="Recipients" required />
+                        </div>
+                        <div class="input-field">
+                            <label for="email-cc">CC</label>
+                            <input type="text" id="email-cc" name="cc" placeholder="CC" />
+                        </div>
+                        <div class="input-field">
+                            <label for="email-bcc">BCC</label>
+                            <input type="text" id="email-bcc" name="bcc" placeholder="BCC" />
+                        </div>
+                        <div class="input-field">
+                            <label for="email-subject">Subject</label>
+                            <input type="text" id="email-subject" name="subject" required />
+                        </div>
+                        <div class="input-field">
+                            <label for="email-body">Content</label>
+                            <textarea id="email-body" name="body" rows="10" required></textarea>
+                        </div>
+                        <div class="checkbox-field">
+                            <input type="checkbox" id="dry-run" name="dry-run" />
+                            <label for="dry-run">Send as Dry Run</label>
+                        </div>
+                        <div class="checkbox-field">
+                            <input type="checkbox" id="html-format" name="html-format" />
+                            <label for="html-format">Content is in HTML</label>
+                        </div>
+                    </fieldset>
                 </div>
-                <div class="input-field">
-                    <label for="email-bcc">BCC</label>
-                    <input type="text" id="email-bcc" name="bcc" placeholder="BCC" />
-                </div>
-                <div class="input-field">
-                    <label for="email-subject">Subject</label>
-                    <input type="text" id="email-subject" name="subject" required />
-                </div>
-                <div class="input-field">
-                    <label for="email-body">Content</label>
-                    <textarea id="email-body" name="body" rows="10" required></textarea>
-                </div>
-                <div class="checkbox-field">
-                    <input type="checkbox" id="dry-run" name="dry-run" />
-                	<label for="dry-run">Send as Dry Run</label>
-                </div>
-                <div class="checkbox-field">
-                    <input type="checkbox" id="html-format" name="html-format" />
-                	<label for="html-format">Content is in HTML</label>
-                </div>
-            </fieldset>
-            <button class="send-email">Send Email</button>
+                <button class="send-email">Send Email</button>
+                <div class="results-area"></div>
+            </div>
         </div>
-        <div class="results-area"></div>
     `;
 
     document.querySelector('button.send-email').addEventListener('click', function(event) {
@@ -132,13 +138,17 @@ function handlerUsers(path, params, context, container) {
 
         let resultsArea = container.querySelector(".results-area");
 
+        let renderResult = function(message) {
+            resultsArea.innerHTML = `<div class="result secondary-color drop-shadow">${message}</div>`;
+        };
+
         Autograder.Course.emailUsers(args)
             .then(function() {
-                resultsArea.innerHTML = '<p>Email sent successfully.</p>';
+                renderResult('<p>Email sent successfully.</p>');
             })
             .catch(function(message) {
                 console.error(message);
-                resultsArea.innerHTML = Render.autograderError(message);
+                renderResult(Render.autograderError(message));
             })
         ;
     });

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -65,28 +65,33 @@ function handlerUsers(path, params, context, container) {
 
     container.innerHTML = `
         <h2>Email Users</h2>
-        <p>Sumbitting this form will send an email to all users enrolled in the course.</p>
-        <p>Please separate email addresses with commas.</p>
-        <fieldset>
-        	<div>
-                <label for='email-to'>To</label>
-                <input type='text' id='email-to' name='to' placeholder='Recipients' required />
-        	<div>
-                <label for='email-cc'>CC</label>
-                <input type='text' id='email-cc' name='cc' placeholder='CC' />
-        	<div>
-                <label for='email-bcc'>BCC</label>
-                <input type='text' id='email-bcc' name='bcc' placeholder='BCC' />
-            </div>
-            <div>
-                <label for='email-subject'>Subject</label>
-                <input type='text' id='email-subject' name='subject' required />
-            </div>
-            <div>
-                <textarea name='body' rows='10' required></textarea>
-            </div>
-        </fieldset>
-        <button class="send-email">Send</button>
+        <div class="email-area">
+            <p>Sumbitting this form will send an email to all users enrolled in the course.</p>
+            <p>Please separate email addresses with commas.</p>
+            <fieldset>
+                <div class="input-field">
+                    <label for="email-to">To</label>
+                    <input type="text" id="email-to" name="to" placeholder="Recipients" required />
+                </div>
+                <div class="input-field">
+                    <label for="email-cc">CC</label>
+                    <input type="text" id="email-cc" name="cc" placeholder="CC" />
+                </div>
+                <div class="input-field">
+                    <label for="email-bcc">BCC</label>
+                    <input type="text" id="email-bcc" name="bcc" placeholder="BCC" />
+                </div>
+                <div class="input-field">
+                    <label for="email-subject">Subject</label>
+                    <input type="text" id="email-subject" name="subject" required />
+                </div>
+                <div class="input-field">
+                    <label for="email-body">Content</label>
+                    <textarea id="email-body" name="body" rows="10" required></textarea>
+                </div>
+            </fieldset>
+            <button class="send-email">Send Email</button>
+        </div>
         <div class="results-area"></div>
     `;
 

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -163,12 +163,8 @@ function handlerEmail(path, params, context, container) {
 function extractRecipients(recipientString) {
     return recipientString
         .split(',')
-        .map(function(recipient) {
-           return recipient.trim();
-        })
-        .filter(function(recipient) {
-            return recipient.length > 0;
-        })
+        .map((recipient) => (recipient.trim()))
+        .filter((recipient) => (recipient.length > 0))
     ;
 }
 

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -6,7 +6,7 @@ function init() {
     let requirements = {course: true};
     Routing.addRoute(/^courses$/, handlerCourses, 'Enrolled Courses');
     Routing.addRoute(/^course$/, handlerCourse, 'Course', {course: true});
-    Routing.addRoute(/^course\/email$/, handlerUsers, 'Email', {course: true});
+    Routing.addRoute(/^course\/email$/, handlerEmail, 'Email', {course: true});
 }
 
 function handlerCourses(path, params, context, container) {
@@ -51,7 +51,7 @@ function handlerCourse(path, params, context, container) {
     `;
 }
 
-function handlerUsers(path, params, context, container) {
+function handlerEmail(path, params, context, container) {
     let course = context.courses[params[Routing.PARAM_COURSE]];
     const courseLink = Routing.formHashPath(Routing.PATH_COURSE, {[Routing.PARAM_COURSE]: course.id});
 

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -89,6 +89,14 @@ function handlerUsers(path, params, context, container) {
                     <label for="email-body">Content</label>
                     <textarea id="email-body" name="body" rows="10" required></textarea>
                 </div>
+                <div class="checkbox-field">
+                    <input type="checkbox" id="dry-run" name="dry-run" />
+                	<label for="dry-run">Send as Dry Run</label>
+                </div>
+                <div class="checkbox-field">
+                    <input type="checkbox" id="html-format" name="html-format" />
+                	<label for="html-format">Content is in HTML</label>
+                </div>
             </fieldset>
             <button class="send-email">Send Email</button>
         </div>
@@ -111,6 +119,8 @@ function handlerUsers(path, params, context, container) {
             [Routing.PARAM_EMAIL_BCC]: extractEmails(container.querySelector("fieldset [name='bcc']").value),
             [Routing.PARAM_EMAIL_SUBJECT]: container.querySelector("fieldset [name='subject']").value,
             [Routing.PARAM_EMAIL_BODY]: container.querySelector("fieldset [name='body']").value,
+            [Routing.PARAM_EMAIL_DRY_RUN]: container.querySelector("fieldset [name='dry-run']").checked,
+            [Routing.PARAM_EMAIL_HTML]: container.querySelector("fieldset [name='html-format']").checked,
         };
 
         for (const key in args) {
@@ -124,9 +134,10 @@ function handlerUsers(path, params, context, container) {
 
         Autograder.Course.emailUsers(args)
             .then(function() {
-                resultsArea.innerHTML = '<p>Email sent successfully!</p>';
+                resultsArea.innerHTML = '<p>Email sent successfully.</p>';
             })
             .catch(function(message) {
+                console.error(message);
                 resultsArea.innerHTML = Render.autograderError(message);
             })
         ;

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -2,6 +2,8 @@ import * as Autograder from '../autograder/base.js';
 import * as Render from './render.js';
 import * as Routing from './routing.js';
 
+const recipientDocsLink = "https://github.com/edulinq/autograder-server/blob/main/docs/types.md#course-user-reference-courseuserreference";
+
 function init() {
     let requirements = {course: true};
     Routing.addRoute(/^courses$/, handlerCourses, 'Enrolled Courses');
@@ -63,14 +65,16 @@ function handlerEmail(path, params, context, container) {
     `;
     Routing.setTitle(course.id, titleHTML);
 
-    let recipientDocsLink = "https://github.com/edulinq/autograder-server/blob/main/docs/types.md#course-user-reference-courseuserreference";
-
     container.innerHTML = `
         <div class="email-page">
             <div class="email-content">
                 <h2>Email Users</h2>
                 <div class="description">
-                    <p>Please separate recipient values with commas. For valid recipient values reference <a href=${recipientDocsLink} target="_blank">documentation</a>.</p>
+                    <p>
+                        Separate recipient values with commas.
+                        For valid recipient values reference 
+                            <a href=${recipientDocsLink} target="_blank">documentation</a>.
+                    </p>
                 </div>
                 <div class="user-input-fields secondary-color drop-shadow">
                     <fieldset>
@@ -137,8 +141,16 @@ function handlerEmail(path, params, context, container) {
         }
 
         Autograder.Course.email(args)
-            .then(function() {
-                renderResult('<p>Email sent successfully.</p>');
+            .then(function(result) {
+                renderResult(`
+                    <p>Email sent successfully.</p>
+                    <p><strong>Recipients</strong> (total ${result[Routing.PARAM_EMAIL_TO].length})</p>
+                    <p>${result[Routing.PARAM_EMAIL_TO].join(', ')}</p>
+                    <p><strong>CC-ed Recipients</strong> (total ${result[Routing.PARAM_EMAIL_CC].length})</p>
+                    <p>${result[Routing.PARAM_EMAIL_CC].join(', ')}</p>
+                    <p><strong>BCC-ed Recipients</strong> (total ${result[Routing.PARAM_EMAIL_BCC].length})</p>
+                    <p>${result[Routing.PARAM_EMAIL_BCC].join(', ')}</p>
+                `);
             })
             .catch(function(message) {
                 console.error(message);

--- a/site/js/modules/webui/routing.js
+++ b/site/js/modules/webui/routing.js
@@ -6,16 +6,16 @@ let routes = [];
 
 const DEFAULT_HANDLER = handlerNotFound
 
-const PARAM_COURSE = 'course';
 const PARAM_ASSIGNMENT = 'assignment';
+const PARAM_COURSE = 'course';
+const PARAM_COURSE_ID = 'course-id';
+const PARAM_DRY_RUN = 'dry-run';
 const PARAM_SUBMISSION = 'submission';
 const PARAM_TARGET_ENDPOINT = 'endpoint';
 
 const PARAM_EMAIL_BCC = 'bcc';
 const PARAM_EMAIL_BODY = 'body';
 const PARAM_EMAIL_CC = 'cc';
-const PARAM_EMAIL_COURSE = 'course-id';
-const PARAM_EMAIL_DRY_RUN = 'dry-run';
 const PARAM_EMAIL_HTML = 'html';
 const PARAM_EMAIL_SUBJECT = 'subject';
 const PARAM_EMAIL_TO = 'to';
@@ -343,19 +343,18 @@ export {
     redirectLogout,
     setTitle,
 
-    PARAM_COURSE,
     PARAM_ASSIGNMENT,
-    PARAM_SUBMISSION,
-    PARAM_TARGET_ENDPOINT,
-
+    PARAM_COURSE,
+    PARAM_COURSE_ID,
+    PARAM_DRY_RUN,
     PARAM_EMAIL_BCC,
     PARAM_EMAIL_BODY,
     PARAM_EMAIL_CC,
-    PARAM_EMAIL_COURSE,
-    PARAM_EMAIL_DRY_RUN,
     PARAM_EMAIL_HTML,
     PARAM_EMAIL_SUBJECT,
     PARAM_EMAIL_TO,
+    PARAM_SUBMISSION,
+    PARAM_TARGET_ENDPOINT,
 
     PATH_COURSE,
     PATH_ASSIGNMENT,

--- a/site/js/modules/webui/routing.js
+++ b/site/js/modules/webui/routing.js
@@ -1,6 +1,6 @@
-import * as Autograder from '../autograder/base.js'
-import * as Context from './context.js'
-import * as Log from './log.js'
+import * as Autograder from '../autograder/base.js';
+import * as Context from './context.js';
+import * as Log from './log.js';
 
 let routes = [];
 
@@ -11,8 +11,16 @@ const PARAM_ASSIGNMENT = 'assignment';
 const PARAM_SUBMISSION = 'submission';
 const PARAM_TARGET_ENDPOINT = 'endpoint';
 
+const PARAM_EMAIL_BCC = 'bcc';
+const PARAM_EMAIL_BODY = 'body';
+const PARAM_EMAIL_CC = 'cc';
+const PARAM_EMAIL_COURSE = 'course-id';
+const PARAM_EMAIL_SUBJECT = 'subject';
+const PARAM_EMAIL_TO = 'to';
+
 const PATH_COURSE = 'course';
 const PATH_ASSIGNMENT = `${PATH_COURSE}/assignment`;
+const PATH_EMAIL = `${PATH_COURSE}/email`;
 const PATH_SUBMIT = `${PATH_ASSIGNMENT}/submit`;
 const PATH_PEEK = `${PATH_ASSIGNMENT}/peek`;
 const PATH_HISTORY = `${PATH_ASSIGNMENT}/history`;
@@ -338,11 +346,19 @@ export {
     PARAM_SUBMISSION,
     PARAM_TARGET_ENDPOINT,
 
+    PARAM_EMAIL_BCC,
+    PARAM_EMAIL_BODY,
+    PARAM_EMAIL_CC,
+    PARAM_EMAIL_COURSE,
+    PARAM_EMAIL_SUBJECT,
+    PARAM_EMAIL_TO,
+
     PATH_COURSE,
     PATH_ASSIGNMENT,
+    PATH_EMAIL,
     PATH_SUBMIT,
     PATH_PEEK,
     PATH_HISTORY,
     PATH_SERVER,
     PATH_SERVER_CALL_API,
-}
+};

--- a/site/js/modules/webui/routing.js
+++ b/site/js/modules/webui/routing.js
@@ -15,6 +15,8 @@ const PARAM_EMAIL_BCC = 'bcc';
 const PARAM_EMAIL_BODY = 'body';
 const PARAM_EMAIL_CC = 'cc';
 const PARAM_EMAIL_COURSE = 'course-id';
+const PARAM_EMAIL_DRY_RUN = 'dry-run';
+const PARAM_EMAIL_HTML = 'html';
 const PARAM_EMAIL_SUBJECT = 'subject';
 const PARAM_EMAIL_TO = 'to';
 
@@ -350,6 +352,8 @@ export {
     PARAM_EMAIL_BODY,
     PARAM_EMAIL_CC,
     PARAM_EMAIL_COURSE,
+    PARAM_EMAIL_DRY_RUN,
+    PARAM_EMAIL_HTML,
     PARAM_EMAIL_SUBJECT,
     PARAM_EMAIL_TO,
 

--- a/site/js/modules/webui/routing.js
+++ b/site/js/modules/webui/routing.js
@@ -10,15 +10,14 @@ const PARAM_ASSIGNMENT = 'assignment';
 const PARAM_COURSE = 'course';
 const PARAM_COURSE_ID = 'course-id';
 const PARAM_DRY_RUN = 'dry-run';
-const PARAM_SUBMISSION = 'submission';
-const PARAM_TARGET_ENDPOINT = 'endpoint';
-
 const PARAM_EMAIL_BCC = 'bcc';
 const PARAM_EMAIL_BODY = 'body';
 const PARAM_EMAIL_CC = 'cc';
 const PARAM_EMAIL_HTML = 'html';
 const PARAM_EMAIL_SUBJECT = 'subject';
 const PARAM_EMAIL_TO = 'to';
+const PARAM_SUBMISSION = 'submission';
+const PARAM_TARGET_ENDPOINT = 'endpoint';
 
 const PATH_COURSE = 'course';
 const PATH_ASSIGNMENT = `${PATH_COURSE}/assignment`;


### PR DESCRIPTION
This PR adds a page for the endpoint `courses/admin/email`. This page can be found after selecting any course card from the courses page under the card "Email Users". The page only displays if the email is sent successfully or an Autograder error. The card is not hidden if the current user does not have the permissions to send emails.

A new file `course.js` is also added to the autograder folder with a single call to `courses/admin/email`. The file is intended to hold course action endpoints.

Page style is currently set to match the style of Call API page.