### PR TITLE
Added the ability to use different credentials on the call api endpoint page.

### DIFF
--- a/site/js/modules/autograder/core.js
+++ b/site/js/modules/autograder/core.js
@@ -60,13 +60,15 @@ function deleteToken(credentials) {
     });
 }
 
-async function resolveAPIResponse(response) {
+async function resolveAPIResponse(response, usingContextUser) {
     let body = await response.json();
 
     if (!body.success) {
         if (response.status == 401) {
-            // Clear any credentials in the cache.
-            clearCredentials(false);
+            if (usingContextUser) {
+                // Clear any credentials in the cache when the context user has an auth error.
+                clearCredentials(false);
+            }
 
             // Shorten the message for auth error.
             return Promise.reject(body.message);
@@ -129,7 +131,11 @@ function sendRequest({
         'body': body,
     });
 
-    return response.then(resolveAPIResponse, resolveAPIError);
+    let usingContextUser = ((override_email == null) && (override_cleartext == null));
+
+    return response.then(function(result) {
+        return resolveAPIResponse(result, usingContextUser);
+    }, resolveAPIError);
 }
 
 export {

--- a/site/js/modules/autograder/core.js
+++ b/site/js/modules/autograder/core.js
@@ -60,12 +60,12 @@ function deleteToken(credentials) {
     });
 }
 
-async function resolveAPIResponse(response, usingContextUser) {
+async function resolveAPIResponse(response, clearContextUser = true) {
     let body = await response.json();
 
     if (!body.success) {
         if (response.status == 401) {
-            if (usingContextUser) {
+            if (clearContextUser) {
                 // Clear any credentials in the cache when the context user has an auth error.
                 clearCredentials(false);
             }
@@ -98,6 +98,7 @@ function sendRequest({
         endpoint = undefined,
         payload = {}, files = [],
         override_email = undefined, override_cleartext = undefined,
+        clearContextUser = true,
         }) {
     if (!endpoint) {
         throw new Error("Endpoint not specified.")
@@ -131,10 +132,8 @@ function sendRequest({
         'body': body,
     });
 
-    let usingContextUser = ((override_email == null) && (override_cleartext == null));
-
     return response.then(function(result) {
-        return resolveAPIResponse(result, usingContextUser);
+        return resolveAPIResponse(result, clearContextUser);
     }, resolveAPIError);
 }
 

--- a/site/js/modules/autograder/core.js
+++ b/site/js/modules/autograder/core.js
@@ -97,7 +97,7 @@ async function resolveAPIError(response) {
 function sendRequest({
         endpoint = undefined,
         payload = {}, files = [],
-        override_email = undefined, override_cleartext = undefined,
+        overrideEmail = undefined, overrideCleartext = undefined,
         clearContextUser = true,
         }) {
     if (!endpoint) {
@@ -110,12 +110,12 @@ function sendRequest({
         payload[REQUEST_USER_PASS_KEY] = credentials.token;
     }
 
-    if (override_email) {
-        payload[REQUEST_USER_EMAIL_KEY] = override_email;
+    if (overrideEmail) {
+        payload[REQUEST_USER_EMAIL_KEY] = overrideEmail;
     }
 
-    if (override_cleartext) {
-        payload[REQUEST_USER_PASS_KEY] = Util.sha256(override_cleartext);
+    if (overrideCleartext) {
+        payload[REQUEST_USER_PASS_KEY] = Util.sha256(overrideCleartext);
     }
 
     let url = `${BASE_URL}/${API_VESION}/${endpoint}`;

--- a/site/js/modules/autograder/server.js
+++ b/site/js/modules/autograder/server.js
@@ -2,12 +2,17 @@ import * as Core from './core.js'
 
 let apiDescription = undefined;
 
-function callEndpoint(targetEndpoint, params, override_email = undefined, override_cleartext = undefined) {
+function callEndpoint({
+        targetEndpoint, params,
+        override_email = undefined, override_cleartext = undefined,
+        clearContextUser = true,
+        }) {
     return Core.sendRequest({
         endpoint: targetEndpoint,
         payload: params,
         override_email: override_email,
         override_cleartext: override_cleartext,
+        clearContextUser: clearContextUser,
     });
 }
 

--- a/site/js/modules/autograder/server.js
+++ b/site/js/modules/autograder/server.js
@@ -2,10 +2,12 @@ import * as Core from './core.js'
 
 let apiDescription = undefined;
 
-function callEndpoint(targetEndpoint, params) {
+function callEndpoint(targetEndpoint, params, override_email = undefined, override_cleartext = undefined) {
     return Core.sendRequest({
         endpoint: targetEndpoint,
         payload: params,
+        override_email: override_email,
+        override_cleartext: override_cleartext,
     });
 }
 

--- a/site/js/modules/autograder/server.js
+++ b/site/js/modules/autograder/server.js
@@ -4,14 +4,14 @@ let apiDescription = undefined;
 
 function callEndpoint({
         targetEndpoint, params,
-        override_email = undefined, override_cleartext = undefined,
+        overrideEmail = undefined, overrideCleartext = undefined,
         clearContextUser = true,
         }) {
     return Core.sendRequest({
         endpoint: targetEndpoint,
         payload: params,
-        override_email: override_email,
-        override_cleartext: override_cleartext,
+        overrideEmail: overrideEmail,
+        overrideCleartext: overrideCleartext,
         clearContextUser: clearContextUser,
     });
 }

--- a/site/js/modules/autograder/users.js
+++ b/site/js/modules/autograder/users.js
@@ -53,8 +53,8 @@ function getServerRoleValue(role) {
 function createToken(email, cleartext) {
     return Core.sendRequest({
         endpoint: 'users/tokens/create',
-        override_email: email,
-        override_cleartext: cleartext,
+        overrideEmail: email,
+        overrideCleartext: cleartext,
     });
 }
 

--- a/site/js/modules/webui/server.js
+++ b/site/js/modules/webui/server.js
@@ -171,6 +171,7 @@ function callEndpoint(targetEndpoint, inputFields, context, container) {
     let override_cleartext = undefined;
 
     let params = {};
+    let clearContextUser = true;
     for (let field of inputFields) {
         let input = container.querySelector(`.endpoint-input fieldset [name="${field.name}"]`);
         if (!input || input.value === "") {
@@ -179,11 +180,13 @@ function callEndpoint(targetEndpoint, inputFields, context, container) {
 
         if (field.name === "user-email") {
             override_email = input.value;
+            clearContextUser = false;
             continue;
         }
 
         if (field.name === "user-pass") {
             override_cleartext = input.value;
+            clearContextUser = false;
             continue;
         }
 
@@ -204,8 +207,13 @@ function callEndpoint(targetEndpoint, inputFields, context, container) {
 
     let resultsArea = container.querySelector(".results-area");
 
-    Autograder.Server.callEndpoint(targetEndpoint, params, override_email, override_cleartext)
-        .then(function(result) {
+    Autograder.Server.callEndpoint({
+            targetEndpoint: targetEndpoint,
+            params: params,
+            override_email: override_email,
+            override_cleartext: override_cleartext,
+            clearContextUser: clearContextUser,
+        }).then(function(result) {
             resultsArea.innerHTML = `
                 <pre><code class="result code code-block secondary-color drop-shadow" data-lang="json">${JSON.stringify(result, null, 4)}</code></pre>
             `;

--- a/site/js/modules/webui/server.js
+++ b/site/js/modules/webui/server.js
@@ -167,11 +167,24 @@ function renderEndpointArea(endpoints, selectedEndpoint, context) {
 function callEndpoint(targetEndpoint, inputFields, context, container) {
     Routing.loadingStart(container.querySelector(".results-area"), false);
 
+    let override_email = undefined;
+    let override_cleartext = undefined;
+
     let params = {};
     for (let field of inputFields) {
         let input = container.querySelector(`.endpoint-input fieldset [name="${field.name}"]`);
         if (!input || input.value === "") {
-            continue
+            continue;
+        }
+
+        if (field.name === "user-email") {
+            override_email = input.value;
+            continue;
+        }
+
+        if (field.name === "user-pass") {
+            override_cleartext = input.value;
+            continue;
         }
 
         if (field.type === "string") {
@@ -191,7 +204,7 @@ function callEndpoint(targetEndpoint, inputFields, context, container) {
 
     let resultsArea = container.querySelector(".results-area");
 
-    Autograder.Server.callEndpoint(targetEndpoint, params)
+    Autograder.Server.callEndpoint(targetEndpoint, params, override_email, override_cleartext)
         .then(function(result) {
             resultsArea.innerHTML = `
                 <pre><code class="result code code-block secondary-color drop-shadow" data-lang="json">${JSON.stringify(result, null, 4)}</code></pre>

--- a/site/js/modules/webui/server.js
+++ b/site/js/modules/webui/server.js
@@ -167,11 +167,11 @@ function renderEndpointArea(endpoints, selectedEndpoint, context) {
 function callEndpoint(targetEndpoint, inputFields, context, container) {
     Routing.loadingStart(container.querySelector(".results-area"), false);
 
-    let override_email = undefined;
-    let override_cleartext = undefined;
+    let overrideEmail = undefined;
+    let overrideCleartext = undefined;
 
     let params = {};
-    let clearContextUser = true;
+
     for (let field of inputFields) {
         let input = container.querySelector(`.endpoint-input fieldset [name="${field.name}"]`);
         if (!input || input.value === "") {
@@ -179,14 +179,12 @@ function callEndpoint(targetEndpoint, inputFields, context, container) {
         }
 
         if (field.name === "user-email") {
-            override_email = input.value;
-            clearContextUser = false;
+            overrideEmail = input.value;
             continue;
         }
 
         if (field.name === "user-pass") {
-            override_cleartext = input.value;
-            clearContextUser = false;
+            overrideCleartext = input.value;
             continue;
         }
 
@@ -210,9 +208,9 @@ function callEndpoint(targetEndpoint, inputFields, context, container) {
     Autograder.Server.callEndpoint({
             targetEndpoint: targetEndpoint,
             params: params,
-            override_email: override_email,
-            override_cleartext: override_cleartext,
-            clearContextUser: clearContextUser,
+            override_email: overrideEmail,
+            override_cleartext: overrideCleartext,
+            clearContextUser: false,
         }).then(function(result) {
             resultsArea.innerHTML = `
                 <pre><code class="result code code-block secondary-color drop-shadow" data-lang="json">${JSON.stringify(result, null, 4)}</code></pre>

--- a/site/js/modules/webui/server.js
+++ b/site/js/modules/webui/server.js
@@ -208,8 +208,8 @@ function callEndpoint(targetEndpoint, inputFields, context, container) {
     Autograder.Server.callEndpoint({
             targetEndpoint: targetEndpoint,
             params: params,
-            override_email: overrideEmail,
-            override_cleartext: overrideCleartext,
+            overrideEmail: overrideEmail,
+            overrideCleartext: overrideCleartext,
             clearContextUser: false,
         }).then(function(result) {
             resultsArea.innerHTML = `


### PR DESCRIPTION
This PR fixes a known issue that prevented users from being able to input different credentials on the call api endpoint page.

Previously, the context user would always be cleared on an auth error. Now, context users are only cleared when the context user itself fails to auth. This avoids clearing a valid context user when the inputted credentials fail to auth.