### PR TITLE
Added infrastructure to create pages from a template.

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -545,14 +545,16 @@ fieldset {
 }
 
 .endpoint-page,
-.email-page {
+.email-page,
+.template-page {
     display: flex;
     flex-direction: row;
     justify-content: center;
 }
 
 .endpoint-content,
-.email-content {
+.email-content,
+.template-content {
     display: flex;
     flex-direction: column;
     align-content: center;
@@ -625,12 +627,17 @@ table.standard-table tr:not(:last-child) {
     margin-left: 0.5em;
 }
 
+.endpoint-content > button,
 .endpoint-content > div,
-.email-content > div {
+.email-content > button,
+.email-content > div,
+.template-content > button,
+.template-content > div {
     display: flex;
     flex-direction: column;
     align-content: center;
     justify-content: center;
+    min-width: 50vw;
     max-width: 95vw;
 
     gap: 1em;
@@ -668,7 +675,8 @@ table.standard-table tr:not(:last-child) {
     margin-bottom: 0em;
 }
 
-.endpoint-input button {
+.endpoint-input button,
+.template-content button {
     padding: 0.5em 0.75em;
 }
 

--- a/site/js/modules/autograder/course.js
+++ b/site/js/modules/autograder/course.js
@@ -7,6 +7,14 @@ function email(params) {
     });
 }
 
+function users(params) {
+    return Core.sendRequest({
+        endpoint: 'courses/users/list',
+        payload: params,
+    });
+}
+
 export {
     email,
+    users,
 };

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -3,7 +3,7 @@ import * as Input from './input.js';
 import * as Render from './render.js';
 import * as Routing from './routing.js';
 
-const EMAIL_RECIPIENT_DOCS_LINK = "https://github.com/edulinq/autograder-server/blob/main/docs/types.md#course-user-reference-courseuserreference";
+const COURSE_USER_REFERENCE_DOC_LINK = "https://github.com/edulinq/autograder-server/blob/main/docs/types.md#course-user-reference-courseuserreference";
 
 function init() {
     let requirements = {course: true};
@@ -83,7 +83,7 @@ function handlerEmail(path, params, context, container) {
                     <p>
                         Separate recipient values with commas.
                         For valid recipient values reference this 
-                        <a href=${EMAIL_RECIPIENT_DOCS_LINK} target="_blank">documentation</a>.
+                        <a href=${COURSE_USER_REFERENCE_DOC_LINK} target="_blank">documentation</a>.
                     </p>
                 </div>
                 <div class="user-input-fields secondary-color drop-shadow">
@@ -181,11 +181,13 @@ function handlerUsers(path, params, context, container) {
         new Input.Field('users', 'Target Users', Routing.PARAM_TARGET_USERS, {extractInputFunc: Input.valueFromJSON}),
     ];
 
+    let description = `List the users in the course. Target users expects a JSON list of <a href=${COURSE_USER_REFERENCE_DOC_LINK} target="_blank">course user references</a>. Defaults to all users in the course.`;
+
     Render.makePage(
             params, context, container,
             {
                 header: 'List Users',
-                description: 'List the users in the course.',
+                description: description,
                 inputs: inputFields,
                 buttonName: 'List Users',
             },

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -178,7 +178,7 @@ function handlerUsers(path, params, context, container) {
     Routing.setTitle(course.id, titleHTML);
 
     let inputFields = [
-        new Input.Field('users', 'Target Users', Routing.PARAM_TARGET_USERS, {marshalFunc: Input.valueFromJSON}),
+        new Input.Field('users', 'Target Users', Routing.PARAM_TARGET_USERS, {extractInputFunc: Input.valueFromJSON}),
     ];
 
     Render.makePage(
@@ -198,7 +198,11 @@ function listUsers(params, context, container, inputParams) {
     inputParams[Routing.PARAM_COURSE_ID] = context.courses[params[Routing.PARAM_COURSE]].id;
     return Autograder.Course.users(inputParams)
         .then(function(result) {
-            return `<pre><code data-lang="json">${JSON.stringify(result, null, 4)}</code></pre>`;
+            if (result.users.length === 0) {
+                return '<p>Unable to find target users.</p>';
+            }
+
+            return `<pre>${Render.listCourseUsers(result.users)}</pre`;
         })
         .catch(function(message) {
             console.error(message);

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -1,6 +1,5 @@
 import * as Autograder from '../autograder/base.js';
 import * as Input from './input.js';
-import * as Model from './model.js';
 import * as Render from './render.js';
 import * as Routing from './routing.js';
 
@@ -185,17 +184,17 @@ function handlerUsers(path, params, context, container) {
     Render.makePage(
             params, context, container,
             {
-                header: 'Get Users',
+                header: 'List Users',
                 description: 'List the users in the course.',
                 inputs: inputFields,
-                buttonName: 'Get Users',
+                buttonName: 'List Users',
             },
-            getUsers,
+            listUsers,
         )
     ;
 }
 
-function getUsers(params, context, container, inputParams) {
+function listUsers(params, context, container, inputParams) {
     inputParams[Routing.PARAM_COURSE_ID] = context.courses[params[Routing.PARAM_COURSE]].id;
     return Autograder.Course.users(inputParams)
         .then(function(result) {
@@ -205,6 +204,7 @@ function getUsers(params, context, container, inputParams) {
             console.error(message);
             return message;
         })
+    ;
 }
 
 function extractRecipients(recipientString) {

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -1,4 +1,5 @@
 import * as Autograder from '../autograder/base.js';
+import * as Input from './input.js';
 import * as Model from './model.js';
 import * as Render from './render.js';
 import * as Routing from './routing.js';
@@ -51,7 +52,7 @@ function handlerCourse(path, params, context, container) {
 
     cards.push(Render.makeCardObject(
         "course-action",
-        "Get Users",
+        "List Users",
         Routing.formHashPath(Routing.PATH_COURSE_USERS_LIST, {
             [Routing.PARAM_COURSE]: course.id,
         }),
@@ -178,7 +179,7 @@ function handlerUsers(path, params, context, container) {
     Routing.setTitle(course.id, titleHTML);
 
     let inputFields = [
-        new Model.InputField('users', 'Target Users', Routing.PARAM_TARGET_USERS),
+        new Input.Field('users', 'Target Users', Routing.PARAM_TARGET_USERS, {marshalFunc: Input.valueFromJSON}),
     ];
 
     Render.makePage(
@@ -214,7 +215,6 @@ function extractRecipients(recipientString) {
     ;
 }
 
-// TODO: Remove and merge with render version.
 function renderResult(message) {
     let resultsArea = document.querySelector(".results-area");
     resultsArea.innerHTML = `<div class="result secondary-color drop-shadow">${message}</div>`;

--- a/site/js/modules/webui/input.js
+++ b/site/js/modules/webui/input.js
@@ -1,21 +1,43 @@
 import * as Autograder from '../autograder/base.js';
 
+// A general representation of a user input field.
 class Field {
     constructor(
-            name, displayName, param,
+            name, displayName, key,
             {
                 type = 'string', required = false, placeholder = '',
-                attributes = '', labelBefore = true, marshalFunc = undefined
+                attributes = '', labelBefore = true, extractInputFunc = undefined
             } = {}) {
+        // The name of the field which will be used for targeting the field.
         this.name = name;
+
+        // The display name that will be shown to the user.
         this.displayName = displayName;
-        this.param = param;
+
+        // The key used for the JSON field.
+        this.key = key;
+
+        // The HTML input type.
+        // For more information about possible types,
+        // see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#input_types.
         this.type = type;
+
+        // Flags the field requires user input.
         this.required = required;
+
+        // The placeholder for the input.
         this.placeholder = placeholder;
+
+        // Any additional attributes to the input field.
+        // If the field is required, the required attribute will be added automatically.
         this.attributes = attributes;
+
+        // Determines the position of the HTML label with respect to the input.
         this.labelBefore = labelBefore;
-        this.marshalFunc = marshalFunc;
+
+        // A custom function for extracting the value from an input.
+        // By default, the input.value will be returned.
+        this.extractInputFunc = extractInputFunc;
     }
 
     validate() {
@@ -27,8 +49,8 @@ class Field {
             console.error(`Input field cannot have an empty display name: ${JSON.stringify(this)}.`);
         }
 
-        if ((this.param == undefined) || (this.param == '')) {
-            console.error(`Input field cannot have an empty param: ${JSON.stringify(this)}.`);
+        if ((this.key == undefined) || (this.key == '')) {
+            console.error(`Input field caKeynnot have an empty key: ${JSON.stringify(this)}.`);
         }
     }
 
@@ -36,11 +58,13 @@ class Field {
         this.validate();
 
         let attributes = this.attributes;
+        let displayName = this.displayName;
         if (this.required) {
             attributes += ' required';
+            displayName += ` <span class="required-color">*</span>`;
         }
 
-        const label = `<label for="${this.name}">${this.displayName}</label>`;
+        const label = `<label for="${this.name}">${displayName}</label>`;
         const input = `<input type="${this.type}" id="${this.name}" name="${this.name}" placeholder="${this.placeholder}" ${attributes}/>`;
 
         if (this.labelBefore) {
@@ -60,8 +84,8 @@ class Field {
         }
     }
 
-    getParam() {
-        return this.param;
+    getKey() {
+        return this.key;
     }
 
     getValue(container) {
@@ -69,8 +93,8 @@ class Field {
         input.classList.add("touched");
 
         let value = undefined;
-        if (this.marshalFunc) {
-            value = this.marshalFunc(input);
+        if (this.extractInputFunc) {
+            value = this.extractInputFunc(input);
         } else {
             if (input == undefined) {
                 return undefined;
@@ -96,6 +120,10 @@ function valueFromJSON(input) {
         return undefined;
     }
 
+    if (input.value === "") {
+        return "";
+    }
+
     let value = undefined;
     // Users can input complex types into text boxes.
     // Attempt to parse the input string into JSON.
@@ -112,6 +140,7 @@ function valueFromJSON(input) {
 
 export {
     Field,
+
     valueFromCheckbox,
     valueFromJSON,
 };

--- a/site/js/modules/webui/input.js
+++ b/site/js/modules/webui/input.js
@@ -5,8 +5,7 @@ class Field {
             name, displayName, param,
             {
                 type = 'string', required = false, placeholder = '',
-                underlyingType = '', attributes = '', labelBefore = true,
-                marshalFunc = undefined
+                attributes = '', labelBefore = true, marshalFunc = undefined
             } = {}) {
         this.name = name;
         this.displayName = displayName;
@@ -14,7 +13,6 @@ class Field {
         this.type = type;
         this.required = required;
         this.placeholder = placeholder;
-        this.underlyingType = underlyingType;
         this.attributes = attributes;
         this.labelBefore = labelBefore;
         this.marshalFunc = marshalFunc;
@@ -68,8 +66,9 @@ class Field {
 
     getValue(container) {
         let input = container.querySelector(`fieldset [name=${this.name}`);
-        let value = undefined;
+        input.classList.add("touched");
 
+        let value = undefined;
         if (this.marshalFunc) {
             value = this.marshalFunc(input);
         } else {

--- a/site/js/modules/webui/model.js
+++ b/site/js/modules/webui/model.js
@@ -1,0 +1,82 @@
+import * as Assignment from './assignment.js';
+
+class InputField {
+    constructor(
+            name, displayName, param,
+            type = 'string', required = false, placeholder = '',
+            underlyingType = '', attributes = '', labelBefore = true) {
+        this.name = name;
+        this.displayName = displayName;
+        this.param = param;
+        this.type = type;
+        this.required = required;
+        this.placeholder = placeholder;
+        this.underlyingType = underlyingType;
+        this.attributes = attributes;
+        this.labelBefore = labelBefore;
+    }
+
+    validate() {
+        if ((this.name == undefined) || (this.name == '')) {
+            console.error(`InputField cannot have an empty name: ${JSON.stringify(this)}`);
+        }
+
+        if ((this.displayName == undefined) || (this.displayName == '')) {
+            console.error(`InputField cannot have an empty display name: ${JSON.stringify(this)}.`);
+        }
+
+        if ((this.param == undefined) || (this.param == '')) {
+            console.error(`InputField cannot have an empty param: ${JSON.stringify(this)}.`);
+        }
+    }
+
+    toHTML() {
+        this.validate();
+
+        let attributes = this.attributes;
+        if (this.required) {
+            attributes += ' required';
+        }
+
+        const label = `<label for="${this.name}">${this.displayName}</label>`;
+        const input = `<input type="${this.type}" id="${this.name}" name="${this.name}" placeholder="${this.placeholder}" ${attributes}/>`;
+
+        if (this.labelBefore) {
+            return `
+                <div class="input-field">
+                    ${label}
+                    ${input}
+                </div>
+            `;
+        } else {
+            return `
+                <div class="input-field">
+                    ${input}
+                    ${label}
+                </div>
+            `;
+        }
+    }
+
+    getParam() {
+        return this.param;
+    }
+
+    // TODO: Need a good way to extract complex values.
+    getValue(container) {
+        let input = container.querySelector(`fieldset [name=${this.name}`);
+
+        let value = undefined;
+        if (this.type === 'checkbox') {
+            value = input.checked;
+        } else {
+            value = input.value;
+        }
+
+        return value;
+    }
+}
+
+export {
+    InputField,
+};

--- a/site/js/modules/webui/render.js
+++ b/site/js/modules/webui/render.js
@@ -39,10 +39,13 @@ function cards(cards) {
     `;
 }
 
+// Create and display a web page that follows a standard template.
+// The template includes a header, description, input area, submission button, and a results area.
+// The page inputs expects a list of Input.Fields, see ./input.js for more information.
 function makePage(
         params, context, container,
         page = {className: '', header: '', description: '', inputs: [], buttonName: 'Submit'},
-        onSubmit) {
+        onSubmitFunc) {
     let inputHTML = '';
     for (const input of page.inputs) {
         inputHTML += input.toHTML();
@@ -69,7 +72,7 @@ function makePage(
     `;
 
     container.querySelector("button").addEventListener("click", function(event) {
-        populateResultsArea(params, context, container, page.inputs, onSubmit);
+        populateResultsArea(params, context, container, page.inputs, onSubmitFunc);
     });
 
     container.querySelector(".user-input-fields fieldset").addEventListener("keydown", function(event) {
@@ -77,7 +80,7 @@ function makePage(
             return;
         }
 
-        populateResultsArea(params, context, container, page.inputs, onSubmit);
+        populateResultsArea(params, context, container, page.inputs, onSubmitFunc);
     });
 
     container.querySelectorAll(".user-input-fields fieldset input").forEach(function(input) {
@@ -87,19 +90,19 @@ function makePage(
     });
 }
 
-function populateResultsArea(params, context, container, inputs, onSubmit) {
+function populateResultsArea(params, context, container, inputs, onSubmitFunc) {
     Routing.loadingStart(container.querySelector(".results-area"), false);
 
     let inputParams = {};
     for (const input of inputs) {
         let value = input.getValue(container);
         if (value != "") {
-            inputParams[input.getParam()] = value;
+            inputParams[input.getKey()] = value;
         }
     }
 
     let resultsArea = container.querySelector(".results-area");
-    onSubmit(params, context, container, inputParams)
+    onSubmitFunc(params, context, container, inputParams)
         .then(function(result) {
             resultsArea.innerHTML = `<div class="result secondary-color drop-shadow">${result}</div>`;
         })
@@ -234,6 +237,22 @@ function submissionQuestions(questions) {
     return questionsHTML.join('');
 }
 
+function listCourseUsers(users) {
+    let messages = [];
+    for (const user of users) {
+        let userParts = [];
+
+        userParts.push(`Email: ${user['email']}`);
+        userParts.push(`Name: ${user['name']}`);
+        userParts.push(`Role: ${user['role']}`);
+        userParts.push(`Email: ${user['email']}`);
+
+        messages.push(`${userParts.join("\n")}`);
+    }
+
+    return messages.join("\n\n");
+}
+
 function makePairedTableRow(label, value, name = undefined) {
     let nameHTML = '';
     if (name) {
@@ -312,6 +331,7 @@ export {
     autograderError,
     card,
     cards,
+    listCourseUsers,
     makeCardObject,
     makePage,
     submission,

--- a/site/js/modules/webui/routing.js
+++ b/site/js/modules/webui/routing.js
@@ -18,10 +18,12 @@ const PARAM_EMAIL_SUBJECT = 'subject';
 const PARAM_EMAIL_TO = 'to';
 const PARAM_SUBMISSION = 'submission';
 const PARAM_TARGET_ENDPOINT = 'endpoint';
+const PARAM_TARGET_USERS = 'target-users';
 
 const PATH_COURSE = 'course';
 const PATH_ASSIGNMENT = `${PATH_COURSE}/assignment`;
 const PATH_EMAIL = `${PATH_COURSE}/email`;
+const PATH_COURSE_USERS_LIST = `${PATH_COURSE}/list`;
 const PATH_SUBMIT = `${PATH_ASSIGNMENT}/submit`;
 const PATH_PEEK = `${PATH_ASSIGNMENT}/peek`;
 const PATH_HISTORY = `${PATH_ASSIGNMENT}/history`;
@@ -355,10 +357,12 @@ export {
     PARAM_EMAIL_TO,
     PARAM_SUBMISSION,
     PARAM_TARGET_ENDPOINT,
+    PARAM_TARGET_USERS,
 
     PATH_COURSE,
     PATH_ASSIGNMENT,
     PATH_EMAIL,
+    PATH_COURSE_USERS_LIST,
     PATH_SUBMIT,
     PATH_PEEK,
     PATH_HISTORY,


### PR DESCRIPTION
This PR introduces the infrastructure to easily create pages from a template. The template supports a header, description, a list of input fields, custom submit button name, and a function to call on submission. The input fields also provide flexibility in extracting information from the field.

By creating common infrastructure, we can quickly create many similar pages that follow the same style. This will reduce the amount of styling work needed later, as we can style all template pages together.

The template infrastructure will need to be expanded in the future to support different types of inputs, such as text areas.