### PR TITLE
Added inline valiation errors for template pages.

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -37,6 +37,8 @@
 
     --color-bg-shadow: #000000;
     --color-text-error: #f40055;
+    --color-light-bg-error: rgba(0, 0, 0, 0.1);
+    --color-dark-bg-error: rgba(255, 255, 255, 0.1);
 
     --curve-radius-small: 10px;
     --curve-radius-large: 20px;
@@ -58,6 +60,7 @@ html {
     --color-bg-tertiary: var(--color-light-bg-tertiary);
 
     --color-bg-accent-primary: var(--color-light-bg-accent-primary);
+    --color-bg-error: var(--color-light-bg-error);
 
     --color-text-primary: var(--color-light-text-primary);
     --color-text-secondary: var(--color-light-text-secondary);
@@ -81,6 +84,7 @@ html {
         --color-bg-tertiary: var(--color-light-bg-tertiary);
 
         --color-bg-accent-primary: var(--color-light-bg-accent-primary);
+        --color-bg-error: var(--color-light-bg-error);
 
         --color-text-primary: var(--color-light-text-primary);
         --color-text-secondary: var(--color-light-text-secondary);
@@ -104,6 +108,7 @@ html {
         --color-bg-tertiary: var(--color-dark-bg-tertiary);
 
         --color-bg-accent-primary: var(--color-dark-bg-accent-primary);
+        --color-bg-error: var(--color-dark-bg-error);
 
         --color-text-primary: var(--color-dark-text-primary);
         --color-text-secondary: var(--color-dark-text-secondary);
@@ -127,6 +132,7 @@ html.light {
     --color-bg-tertiary: var(--color-light-bg-tertiary);
 
     --color-bg-accent-primary: var(--color-light-bg-accent-primary);
+    --color-bg-error: var(--color-light-bg-error);
 
     --color-text-primary: var(--color-light-text-primary);
     --color-text-secondary: var(--color-light-text-secondary);
@@ -148,6 +154,7 @@ html.dark {
     --color-bg-tertiary: var(--color-dark-bg-tertiary);
 
     --color-bg-accent-primary: var(--color-dark-bg-accent-primary);
+    --color-bg-error: var(--color-dark-bg-error);
 
     --color-text-primary: var(--color-dark-text-primary);
     --color-text-secondary: var(--color-dark-text-secondary);
@@ -630,6 +637,28 @@ table.standard-table tr:not(:last-child) {
 .template-control-area .checkbox-field label {
     margin-bottom: 0em;
     margin-left: 0.5em;
+}
+
+.user-input-fields .input-field .error-message {
+    /* Hide the error message box by default. */
+    display: none;
+
+    color: var(--color-text-error);
+    background-color: var(--color-bg-error);
+    border-radius: var(--curve-radius-small);
+
+    /* Add a small margin to account for the input field's drop shadow. */
+    margin-top: 2px;
+    margin-bottom: 0.25em;
+    padding: 0.5em 0.75em;
+}
+
+.user-input-fields .input-field .error-message.show {
+    display: block;
+}
+
+.user-input-fields .input-field .error-message p {
+    margin: 0em;
 }
 
 .template-content .page-information {

--- a/site/js/modules/webui/render.js
+++ b/site/js/modules/webui/render.js
@@ -166,6 +166,24 @@ function makePage(
     container.querySelectorAll(".user-input-fields fieldset input")?.forEach(function(input) {
         input.addEventListener("blur", function(event) {
             input.classList.add("touched");
+
+            let currentPageInput = undefined;
+            for (const pageInput of page.inputs) {
+                if (pageInput.name === input.name) {
+                    currentPageInput = pageInput;
+                    break;
+                }
+            }
+
+            // Validate the input after the field loses focus.
+            if (currentPageInput) {
+                try {
+                    currentPageInput.getFieldInstance(container);
+                } catch (error) {
+                    console.error(error);
+                    return;
+                }
+            }
         });
     });
 }
@@ -181,7 +199,6 @@ function submitInputs(params, context, container, inputs, onSubmitFunc) {
         try {
             result = input.getFieldInstance(container);
         } catch (error) {
-            console.error(error);
             errorMessages.push(error.message);
             continue;
         }


### PR DESCRIPTION
This PR adds support for inline validation errors for pages that use the template.

Currently, fields are highlighted red if the field fails basic validation and the user must hover over the field to see an error message. The fields are fully validated (including any custom input validation functions) once the user tries to submit. If fields fail the final validation, then the fields with errors and the corresponding error messages are displayed to the user in the results area.

This PR addresses the issues with the current approach (difficult to quickly see error messages and only performing final validation upon attempted submission) by validating each field after it loses focus. Now, users can see the error message clearly by looking directly under the field with the error.

A final validation pass is still performed upon submissions that generates reminders to check the appropriate fields in the results area.