### PR TITLE
Added submission blocking while processing a request on template pages.

### DIFF
--- a/site/js/modules/webui/render.js
+++ b/site/js/modules/webui/render.js
@@ -210,7 +210,10 @@ function submitInputs(params, context, container, inputs, onSubmitFunc) {
         return;
     }
 
-    button.disabled = true;
+    if (button) {
+        button.disabled = true;
+    }
+
     onSubmitFunc(params, context, container, inputParams)
         .then(function(result) {
             resultsArea.innerHTML = `<div class="result secondary-color drop-shadow">${result}</div>`;
@@ -220,7 +223,9 @@ function submitInputs(params, context, container, inputs, onSubmitFunc) {
             resultsArea.innerHTML = `<div class="result secondary-color drop-shadow">${message}</div>`;
         })
         .finally(function() {
-            button.disabled = false;
+            if (button) {
+                button.disabled = false;
+            }
         })
     ;
 }

--- a/site/js/modules/webui/render.js
+++ b/site/js/modules/webui/render.js
@@ -171,6 +171,12 @@ function makePage(
 }
 
 function submitInputs(params, context, container, inputs, onSubmitFunc) {
+    // If the button is blocked, the server is processing the previous request.
+    let button = container.querySelector(".input-area .template-button");
+    if (button?.disabled) {
+        return;
+    }
+
     Routing.loadingStart(container.querySelector(".results-area"), false);
 
     let inputParams = {};
@@ -204,6 +210,7 @@ function submitInputs(params, context, container, inputs, onSubmitFunc) {
         return;
     }
 
+    button.disabled = true;
     onSubmitFunc(params, context, container, inputParams)
         .then(function(result) {
             resultsArea.innerHTML = `<div class="result secondary-color drop-shadow">${result}</div>`;
@@ -211,6 +218,9 @@ function submitInputs(params, context, container, inputs, onSubmitFunc) {
         .catch(function(message) {
             console.error(message);
             resultsArea.innerHTML = `<div class="result secondary-color drop-shadow">${message}</div>`;
+        })
+        .finally(function() {
+            button.disabled = false;
         })
     ;
 }


### PR DESCRIPTION
This PR blocks repeated submissions on template pages by disabling the button while a request is being processed by the server. The status of the button is checked to see if new submissions should be blocked. So, submissions made by other methods, such as hitting enter while filling out the fields, are also blocked.

The PR hopes to reduce spam / accidental submissions to the server (e.g., accidentally clicking twice, sticky Enter keys registering multiple times, etc.).

In the future, the web GUI may want support for cancelling a request. A user may preemptively submits a request and want to change the request before a response is received. So, the GUI could provide a "cancel" button and to allow the user to resubmit faster.