### PR TITLE
Added role based card filtering to hide unnecessary cards.

### DIFF
--- a/site/js/modules/webui/assignment.js
+++ b/site/js/modules/webui/assignment.js
@@ -54,16 +54,25 @@ function handlerAssignment(path, params, context, container) {
             'assignment-action',
             'Submit',
             Routing.formHashPath(Routing.PATH_SUBMIT, args),
+            'user',
+            'student',
+            course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Peek a Previous Submission',
             Routing.formHashPath(Routing.PATH_PEEK, args),
+            'user',
+            'student',
+            course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'View Submission History',
             Routing.formHashPath(Routing.PATH_HISTORY, args),
+            'user',
+            'student',
+            course.id,
         ),
 
         // Advanced Actions
@@ -71,42 +80,63 @@ function handlerAssignment(path, params, context, container) {
             'assignment-action',
             'Fetch Course Scores',
             Routing.formHashPath(Routing.PATH_ASSIGNMENT_FETCH_COURSE_SCORES, args),
+            'user',
+            'grader',
+            course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Proxy Regrade',
             Routing.formHashPath(Routing.PATH_PROXY_REGRADE, args),
+            'user',
+            'grader',
+            course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Proxy Resubmit',
             Routing.formHashPath(Routing.PATH_PROXY_RESUBMIT, args),
+            'user',
+            'grader',
+            course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Individual Analysis',
             Routing.formHashPath(Routing.PATH_ANALYSIS_INDIVIDUAL, args),
+            'user',
+            'admin',
+            course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Pairwise Analysis',
             Routing.formHashPath(Routing.PATH_ANALYSIS_PAIRWISE, args),
+            'user',
+            'admin',
+            course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Remove Submission',
             Routing.formHashPath(Routing.PATH_SUBMIT_REMOVE, args),
+            'user',
+            'grader',
+            course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'View User History',
             Routing.formHashPath(Routing.PATH_USER_HISTORY, args),
+            'user',
+            'grader',
+            course.id,
         ),
     ];
 
     container.innerHTML = `
         <h2>${assignment.name}</h2>
-        ${Render.cards(cards)}
+        ${Render.cards(context, cards)}
     `;
 }
 

--- a/site/js/modules/webui/assignment.js
+++ b/site/js/modules/webui/assignment.js
@@ -54,24 +54,24 @@ function handlerAssignment(path, params, context, container) {
             'assignment-action',
             'Submit',
             Routing.formHashPath(Routing.PATH_SUBMIT, args),
-            'user',
-            'student',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_STUDENT,
             course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Peek a Previous Submission',
             Routing.formHashPath(Routing.PATH_PEEK, args),
-            'user',
-            'student',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_STUDENT,
             course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'View Submission History',
             Routing.formHashPath(Routing.PATH_HISTORY, args),
-            'user',
-            'student',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_STUDENT,
             course.id,
         ),
 
@@ -80,63 +80,68 @@ function handlerAssignment(path, params, context, container) {
             'assignment-action',
             'Fetch Course Scores',
             Routing.formHashPath(Routing.PATH_ASSIGNMENT_FETCH_COURSE_SCORES, args),
-            'user',
-            'grader',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_GRADER,
             course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Proxy Regrade',
             Routing.formHashPath(Routing.PATH_PROXY_REGRADE, args),
-            'user',
-            'grader',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_GRADER,
             course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Proxy Resubmit',
             Routing.formHashPath(Routing.PATH_PROXY_RESUBMIT, args),
-            'user',
-            'grader',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_GRADER,
             course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Individual Analysis',
             Routing.formHashPath(Routing.PATH_ANALYSIS_INDIVIDUAL, args),
-            'user',
-            'admin',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_ADMIN,
             course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Pairwise Analysis',
             Routing.formHashPath(Routing.PATH_ANALYSIS_PAIRWISE, args),
-            'user',
-            'admin',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_ADMIN,
             course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'Remove Submission',
             Routing.formHashPath(Routing.PATH_SUBMIT_REMOVE, args),
-            'user',
-            'grader',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_GRADER,
             course.id,
         ),
         Render.makeCardObject(
             'assignment-action',
             'View User History',
             Routing.formHashPath(Routing.PATH_USER_HISTORY, args),
-            'user',
-            'grader',
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_GRADER,
             course.id,
         ),
     ];
 
+    let cardHTML = Render.cards(context, cards);
+    if (!cardHTML) {
+        cardHTML = '';
+    }
+
     container.innerHTML = `
         <h2>${assignment.name}</h2>
-        ${Render.cards(context, cards)}
+        ${cardHTML}
     `;
 }
 

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -17,7 +17,14 @@ function handlerCourses(path, params, context, container) {
     let cards = [];
     for (const [id, course] of Object.entries(context.courses)) {
         let link = Routing.formHashPath(Routing.PATH_COURSE, {[Routing.PARAM_COURSE]: course.id});
-        cards.push(Render.makeCardObject('course', course.name, link, 'user', 'other', id));
+        cards.push(Render.makeCardObject(
+            'course',
+            course.name,
+            link,
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_OTHER,
+            id,
+        ));
     }
 
     container.innerHTML = `
@@ -38,7 +45,14 @@ function handlerCourse(path, params, context, container) {
         };
 
         let link = Routing.formHashPath(Routing.PATH_ASSIGNMENT, args);
-        assignmentCards.push(Render.makeCardObject('assignment', assignment.name, link, 'user', 'other', course.id));
+        assignmentCards.push(Render.makeCardObject(
+            'assignment',
+            assignment.name,
+            link,
+            Autograder.Users.SERVER_ROLE_USER,
+            Autograder.Users.COURSE_ROLE_OTHER,
+            course.id,
+        ));
     }
 
     let actionCards = [];
@@ -48,8 +62,8 @@ function handlerCourse(path, params, context, container) {
         Routing.formHashPath(Routing.PATH_EMAIL, {
             [Routing.PARAM_COURSE]: course.id,
         }),
-        'user',
-        'grader',
+        Autograder.Users.SERVER_ROLE_USER,
+        Autograder.Users.COURSE_ROLE_GRADER,
         course.id,
     ));
 
@@ -59,8 +73,8 @@ function handlerCourse(path, params, context, container) {
         Routing.formHashPath(Routing.PATH_COURSE_USERS_LIST, {
             [Routing.PARAM_COURSE]: course.id,
         }),
-        'user',
-        'grader',
+        Autograder.Users.SERVER_ROLE_USER,
+        Autograder.Users.COURSE_ROLE_GRADER,
         course.id,
     ));
 

--- a/site/js/modules/webui/course.js
+++ b/site/js/modules/webui/course.js
@@ -17,11 +17,11 @@ function handlerCourses(path, params, context, container) {
     let cards = [];
     for (const [id, course] of Object.entries(context.courses)) {
         let link = Routing.formHashPath(Routing.PATH_COURSE, {[Routing.PARAM_COURSE]: course.id});
-        cards.push(Render.makeCardObject('course', course.name, link));
+        cards.push(Render.makeCardObject('course', course.name, link, 'user', 'other', id));
     }
 
     container.innerHTML = `
-        ${Render.cards(cards)}
+        ${Render.cards(context, cards)}
     `;
 }
 
@@ -38,7 +38,7 @@ function handlerCourse(path, params, context, container) {
         };
 
         let link = Routing.formHashPath(Routing.PATH_ASSIGNMENT, args);
-        assignmentCards.push(Render.makeCardObject('assignment', assignment.name, link));
+        assignmentCards.push(Render.makeCardObject('assignment', assignment.name, link, 'user', 'other', course.id));
     }
 
     let actionCards = [];
@@ -48,6 +48,9 @@ function handlerCourse(path, params, context, container) {
         Routing.formHashPath(Routing.PATH_EMAIL, {
             [Routing.PARAM_COURSE]: course.id,
         }),
+        'user',
+        'grader',
+        course.id,
     ));
 
     actionCards.push(Render.makeCardObject(
@@ -56,6 +59,9 @@ function handlerCourse(path, params, context, container) {
         Routing.formHashPath(Routing.PATH_COURSE_USERS_LIST, {
             [Routing.PARAM_COURSE]: course.id,
         }),
+        'user',
+        'grader',
+        course.id,
     ));
 
     let cardSections = [
@@ -65,7 +71,7 @@ function handlerCourse(path, params, context, container) {
 
     container.innerHTML = `
         <h2>${course.name}</h2>
-        ${Render.makeCardSections(cardSections)}
+        ${Render.makeCardSections(context, cardSections)}
     `;
 }
 

--- a/site/js/modules/webui/course.test.js
+++ b/site/js/modules/webui/course.test.js
@@ -21,19 +21,42 @@ test("Enrolled Courses", async function() {
 test("Nav Course101", async function() {
     Base.init(false);
 
-    await TestUtil.loginUser("course-student");
-
-    let targetCourse = 'course101';
-    await navigateToCourse(targetCourse);
-
-    TestUtil.checkPageBasics(targetCourse, 'course');
-
-    const expectedLabelNames = [
-        'Homework 0',
-        'Email Users',
-        'List Users',
+    // Each test case is a list of [user, [expected card labels]].
+    const testCases = [
+        [
+            "course-other",
+            [
+                'Homework 0',
+            ],
+        ],
+        [
+            "course-student",
+            [
+                'Homework 0',
+            ],
+        ],
+        [
+            "course-grader",
+            [
+                'Homework 0',
+                'Email Users',
+                'List Users',
+            ],
+        ],
     ];
-    TestUtil.checkCards(expectedLabelNames);
+
+    for (const testCase of testCases) {
+        const user = testCase[0];
+        await TestUtil.loginUser(user);
+
+        const targetCourse = 'course101';
+        await navigateToCourse(targetCourse);
+
+        TestUtil.checkPageBasics(targetCourse, 'course');
+
+        const expectedLabelNames = testCase[1];
+        TestUtil.checkCards(expectedLabelNames);
+    }
 });
 
 async function navigateToEnrolledCourses() {

--- a/site/js/modules/webui/course.test.js
+++ b/site/js/modules/webui/course.test.js
@@ -3,10 +3,10 @@ import * as Event from './event.js';
 import * as Routing from './routing.js';
 import * as TestUtil from './test/util.js';
 
-test("Enrolled Courses", async function() {
+test('Enrolled Courses', async function() {
     Base.init(false);
 
-    await TestUtil.loginUser("course-student");
+    await TestUtil.loginUser('course-student');
     await navigateToEnrolledCourses();
 
     TestUtil.checkPageBasics('Enrolled Courses', 'enrolled courses');
@@ -18,25 +18,25 @@ test("Enrolled Courses", async function() {
     TestUtil.checkCards(expectedLabelNames);
 });
 
-test("Nav Course101", async function() {
+test('Nav Course101', async function() {
     Base.init(false);
 
     // Each test case is a list of [user, [expected card labels]].
     const testCases = [
         [
-            "course-other",
+            'course-other',
             [
                 'Homework 0',
             ],
         ],
         [
-            "course-student",
+            'course-student',
             [
                 'Homework 0',
             ],
         ],
         [
-            "course-grader",
+            'course-grader',
             [
                 'Homework 0',
                 'Email Users',
@@ -53,6 +53,68 @@ test("Nav Course101", async function() {
         await navigateToCourse(targetCourse);
 
         TestUtil.checkPageBasics(targetCourse, 'course');
+
+        const expectedLabelNames = testCase[1];
+        TestUtil.checkCards(expectedLabelNames);
+    }
+});
+
+test('Nav HW0', async function() {
+    Base.init(false);
+
+    // Each test case is a list of [user, [expected card labels]].
+    const testCases = [
+        [
+            'course-other',
+            [],
+        ],
+        [
+            'course-student',
+            [
+                'Peek a Previous Submission',
+                'Submit',
+                'View Submission History',
+            ],
+        ],
+        [
+            'course-grader',
+            [
+                'Fetch Course Scores',
+                'Peek a Previous Submission',
+                'Proxy Regrade',
+                'Proxy Resubmit',
+                'Remove Submission',
+                'Submit',
+                'View Submission History',
+                'View User History',
+            ],
+        ],
+        [
+            'course-admin',
+            [
+                'Fetch Course Scores',
+                'Individual Analysis',
+                'Pairwise Analysis',
+                'Peek a Previous Submission',
+                'Proxy Regrade',
+                'Proxy Resubmit',
+                'Remove Submission',
+                'Submit',
+                'View Submission History',
+                'View User History',
+            ],
+        ],
+    ];
+
+    for (const testCase of testCases) {
+        const user = testCase[0];
+        await TestUtil.loginUser(user);
+
+        const targetCourse = 'course101';
+        const targetAssignment = 'hw0';
+        await navigateToAssignment(targetCourse, targetAssignment);
+
+        TestUtil.checkPageBasics('hw0 :: Autograder', 'assignment');
 
         const expectedLabelNames = testCase[1];
         TestUtil.checkCards(expectedLabelNames);
@@ -82,4 +144,19 @@ async function navigateToCourse(courseId) {
 
     Routing.routeComponents(pathComponents);
     await courseRenderedPromise;
+}
+
+async function navigateToAssignment(courseId, assignmentId) {
+    let pathComponents = {
+        'path': Routing.PATH_ASSIGNMENT,
+        'params': {
+            [Routing.PARAM_ASSIGNMENT]: assignmentId,
+            [Routing.PARAM_COURSE]: courseId,
+        },
+    };
+
+    let assignmentRenderedPromise = Event.getEventPromise(Event.EVENT_TYPE_ROUTING_COMPLETE, pathComponents);
+
+    Routing.routeComponents(pathComponents);
+    await assignmentRenderedPromise;
 }

--- a/site/js/modules/webui/render.js
+++ b/site/js/modules/webui/render.js
@@ -4,18 +4,18 @@ import * as Assignment from './assignment.js';
 import * as Routing from './routing.js';
 import * as Util from './util.js';
 
-function makeCardObject(type = 'unknown', text = '', link = '#', minServerRole = 'unknown', minCourseRole = 'unknown', courseId = undefined) {
+function makeCardObject(type = 'unknown', text = '', link = '#', minServerRole = Autograder.Users.SERVER_ROLE_UNKNOWN, minCourseRole = Autograder.Users.COURSE_ROLE_UNKNOWN, courseId = undefined) {
     return {
-        type:               type,
-        text:               text,
-        link:               link,
-        minServerRoleValue: Autograder.Users.getServerRoleValue(minServerRole),
-        minCourseRoleValue: Autograder.Users.getCourseRoleValue(minCourseRole),
-        courseId:           courseId,
+        type:          type,
+        text:          text,
+        link:          link,
+        minServerRole: minServerRole,
+        minCourseRole: minCourseRole,
+        courseId:      courseId,
     };
 }
 
-function card(card = {type: 'unknown', text: '', link: '#', minServerRole: 'unknown', minCourseRole: 'unknown', courseId: undefined}) {
+function card(card = {type: 'unknown', text: '', link: '#', minServerRole: Autograder.Users.SERVER_ROLE_UNKNOWN, minCourseRole: Autograder.Users.COURSE_ROLE_UNKNOWN, courseId: undefined}) {
     return `
         <div class='card card-${card.type} secondary-color drop-shadow'>
             <a href='${card.link}' alt='${card.text}'>
@@ -53,25 +53,24 @@ function cards(context, cards) {
 }
 
 function hideCard(context, card) {
-    const userServerRoleValue = Autograder.Users.getServerRoleValue(context.user.role);
+    const userServerRole = Autograder.Users.getServerRoleValue(context.user.role);
 
     // Never hide cards from user that is a server admin or above.
-    if (userServerRoleValue >= Autograder.Users.getServerRoleValue('admin')) {
+    if (userServerRole >= Autograder.Users.SERVER_ROLE_ADMIN) {
         return false;
     }
 
-    if (card.minServerRoleValue > userServerRoleValue) {
+    if (card.minServerRole > userServerRole) {
         return true;
     }
 
-    let userCourseRole = 'unknown';
-
+    let userCourseRole = Autograder.Users.COURSE_ROLE_UNKNOWN;
     const course = context.user.courses[card.courseId];
     if (course) {
-        userCourseRole = course.role;
+        userCourseRole = Autograder.Users.getCourseRoleValue(course.role);
     }
 
-    if (card.minCourseRoleValue > Autograder.Users.getCourseRoleValue(userCourseRole)) {
+    if (card.minCourseRole > userCourseRole) {
         return true;
     }
 

--- a/site/js/modules/webui/render.js
+++ b/site/js/modules/webui/render.js
@@ -55,7 +55,7 @@ function cards(context, cards) {
 function hideCard(context, card) {
     const userServerRole = Autograder.Users.getServerRoleValue(context.user.role);
 
-    // Never hide cards from user that is a server admin or above.
+    // Never hide cards from server admins or above.
     if (userServerRole >= Autograder.Users.SERVER_ROLE_ADMIN) {
         return false;
     }

--- a/site/js/modules/webui/server.js
+++ b/site/js/modules/webui/server.js
@@ -32,11 +32,11 @@ function handlerServer(path, params, context, container) {
     let cards = [
         Render.makeCardObject('server-action', 'API Documentation', Routing.formHashPath(Routing.PATH_SERVER_DOCS)),
         Render.makeCardObject('server-action', 'Call API', Routing.formHashPath(Routing.PATH_SERVER_CALL_API, args)),
-        Render.makeCardObject('server-action', 'List Users', Routing.formHashPath(Routing.PATH_SERVER_USERS_LIST, args)),
+        Render.makeCardObject('server-action', 'List Users', Routing.formHashPath(Routing.PATH_SERVER_USERS_LIST, args), 'admin'),
     ];
 
     container.innerHTML = `
-        ${Render.cards(cards)}
+        ${Render.cards(context, cards)}
     `;
 }
 

--- a/site/js/modules/webui/server.js
+++ b/site/js/modules/webui/server.js
@@ -32,7 +32,7 @@ function handlerServer(path, params, context, container) {
     let cards = [
         Render.makeCardObject('server-action', 'API Documentation', Routing.formHashPath(Routing.PATH_SERVER_DOCS)),
         Render.makeCardObject('server-action', 'Call API', Routing.formHashPath(Routing.PATH_SERVER_CALL_API, args)),
-        Render.makeCardObject('server-action', 'List Users', Routing.formHashPath(Routing.PATH_SERVER_USERS_LIST, args), 'admin'),
+        Render.makeCardObject('server-action', 'List Users', Routing.formHashPath(Routing.PATH_SERVER_USERS_LIST, args), Autograder.Users.SERVER_ROLE_ADMIN),
     ];
 
     container.innerHTML = `

--- a/site/js/modules/webui/server.test.js
+++ b/site/js/modules/webui/server.test.js
@@ -1,0 +1,57 @@
+import * as Base from './base.js';
+import * as Event from './event.js';
+import * as Routing from './routing.js';
+import * as TestUtil from './test/util.js';
+
+test('Nav Server Actions', async function() {
+    Base.init(false);
+
+    // Each test case is a list of [user, [expected card labels]].
+    const testCases = [
+        [
+            'server-user',
+            [
+                'API Documentation',
+                'Call API',
+            ],
+        ],
+        [
+            'server-creator',
+            [
+                'API Documentation',
+                'Call API',
+            ],
+        ],
+        [
+            'server-admin',
+            [
+                'API Documentation',
+                'Call API',
+                'List Users',
+            ],
+        ],
+    ];
+
+    for (const testCase of testCases) {
+        const user = testCase[0];
+        await TestUtil.loginUser(user);
+
+        await navigateToServerActions();
+
+        TestUtil.checkPageBasics('Server Actions', 'server actions');
+
+        const expectedLabelNames = testCase[1];
+        TestUtil.checkCards(expectedLabelNames);
+    }
+});
+
+async function navigateToServerActions() {
+    let pathComponents = {
+        'path': Routing.PATH_SERVER,
+    };
+
+    let serverActionsRenderedPromise = Event.getEventPromise(Event.EVENT_TYPE_ROUTING_COMPLETE, pathComponents);
+
+    Routing.routeComponents(pathComponents);
+    await serverActionsRenderedPromise;
+}


### PR DESCRIPTION
This PR adds role based filtering to cards which is used to hide cards from the users that cannot take the action. The URLs are not blocked, as this is not a security issue. The server handles authentication, so calling the endpoint from one of these URLs would respond with an HTTP 403 Bad Auth.

This PR also includes some basic tests that check the cards are properly hidden based on various users.

This PR resolves issue https://github.com/edulinq/autograder-web/issues/25.