### PR TITLE
Web GUI: add server logs query page

### DIFF
--- a/site/js/modules/autograder/index.js
+++ b/site/js/modules/autograder/index.js
@@ -2,6 +2,7 @@ export * from './core.js'
 
 export * as Common from './common/index.js'
 export * as Courses from './courses/index.js'
+export * as Logs from './logs/index.js'
 export * as Metadata from './metadata/index.js'
 export * as Misc from './misc/index.js'
 export * as Users from './users/index.js'

--- a/site/js/modules/autograder/logs/index.js
+++ b/site/js/modules/autograder/logs/index.js
@@ -1,0 +1,1 @@
+export * from './query.js';

--- a/site/js/modules/autograder/logs/query.js
+++ b/site/js/modules/autograder/logs/query.js
@@ -1,0 +1,12 @@
+import * as Core from '../core.js'
+
+function query(params) {
+    return Core.sendRequest({
+        endpoint: 'logs/query',
+        payload: params,
+    });
+}
+
+export {
+    query,
+}

--- a/site/js/modules/webui/core/routing.js
+++ b/site/js/modules/webui/core/routing.js
@@ -41,6 +41,7 @@ const PATH_SERVER = 'server';
 const PATH_SERVER_CALL_API = `${PATH_SERVER}/call-api`;
 const PATH_SERVER_DOCS = `${PATH_SERVER}/docs`;
 const PATH_SERVER_COURSES_LIST = `${PATH_SERVER}/courses/list`;
+const PATH_SERVER_LOGS = `${PATH_SERVER}/logs`;
 const PATH_SERVER_USERS_LIST = `${PATH_SERVER}/users/list`;
 
 const NAV_COURSES = 'Courses';
@@ -441,6 +442,7 @@ export {
     PATH_SERVER_CALL_API,
     PATH_SERVER_DOCS,
     PATH_SERVER_COURSES_LIST,
+    PATH_SERVER_LOGS,
     PATH_SERVER_USERS_LIST,
     PATH_USER_HISTORY,
 

--- a/site/js/modules/webui/server/index.js
+++ b/site/js/modules/webui/server/index.js
@@ -1,5 +1,6 @@
 export * from './apidocs.js';
 export * from './callendpoint.js';
 export * from './list.js';
+export * from './logs.js';
 export * from './server.js';
 export * from './users.js';

--- a/site/js/modules/webui/server/logs.js
+++ b/site/js/modules/webui/server/logs.js
@@ -9,60 +9,51 @@ const LOG_LEVELS = [
     'WARN',
     'ERROR',
     'FATAL',
-    'OFF',
 ];
 
 function init() {
-    Core.Routing.addRoute(Core.Routing.PATH_SERVER_LOGS, handlerLogs, 'View Logs', Core.Routing.NAV_SERVER);
+    Core.Routing.addRoute(Core.Routing.PATH_SERVER_LOGS, handlerLogs, 'View Server Logs', Core.Routing.NAV_SERVER);
 }
 
 function handlerLogs(path, params, context, container) {
-    Render.setTabTitle('View Logs');
+    Render.setTabTitle('View Server Logs');
 
     let levelChoices = LOG_LEVELS.map(function(level) {
         return new Render.SelectOption(level);
     });
 
     let inputFields = [
-        new Render.FieldType(context, 'level', 'Level', {
+        new Render.FieldType(context, 'level', 'Minimum Level', {
             type: Render.INPUT_TYPE_SELECT,
             choices: levelChoices,
             defaultValue: 'INFO',
         }),
-        new Render.FieldType(context, 'target-email', 'Target Email', {
+        new Render.FieldType(context, 'target-email', 'User Email', {
             type: Render.INPUT_TYPE_EMAIL,
         }),
-        new Render.FieldType(context, 'target-course', 'Target Course'),
-        new Render.FieldType(context, 'target-assignment', 'Target Assignment'),
-        new Render.FieldType(context, 'after', 'After Timestamp'),
-        new Render.FieldType(context, 'past', 'Past Window', {
-            placeholder: 'Example: 24h',
+        new Render.FieldType(context, 'target-course', 'Course ID'),
+        new Render.FieldType(context, 'target-assignment', 'Assignment ID'),
+        new Render.FieldType(context, 'after', 'After (timestamp)'),
+        new Render.FieldType(context, 'past', 'Past Timespan', {
+            placeholder: "Timespan, e.g., '24h'",
         }),
     ];
 
     Render.makePage(
         params, context, container, queryLogs,
         {
-            header: 'View Logs',
+            header: 'View Server Logs',
             description: 'Query server logs by level and optional filters.',
             inputs: inputFields,
-            buttonName: 'Query Logs',
+            buttonName: 'Query',
             iconName: Render.ICON_NAME_LIST,
         },
     );
 }
 
 function queryLogs(params, context, container, inputParams) {
-    return Autograder.Misc.callEndpoint({
-            targetEndpoint: 'logs/query',
-            params: inputParams,
-            clearContextUser: false,
-        })
+    return Autograder.Logs.query(inputParams)
         .then(function(result) {
-            if (!result.success) {
-                return Render.autograderError(result?.error?.message ?? 'Failed to query logs.');
-            }
-
             if (result.results.length === 0) {
                 return '<p>No logs matched your query.</p>';
             }

--- a/site/js/modules/webui/server/logs.js
+++ b/site/js/modules/webui/server/logs.js
@@ -1,0 +1,91 @@
+import * as Autograder from '../../autograder/index.js';
+import * as Core from '../core/index.js';
+import * as Render from '../render/index.js';
+
+const LOG_LEVELS = [
+    'TRACE',
+    'DEBUG',
+    'INFO',
+    'WARN',
+    'ERROR',
+    'FATAL',
+    'OFF',
+];
+
+function init() {
+    Core.Routing.addRoute(Core.Routing.PATH_SERVER_LOGS, handlerLogs, 'View Logs', Core.Routing.NAV_SERVER);
+}
+
+function handlerLogs(path, params, context, container) {
+    Render.setTabTitle('View Logs');
+
+    let levelChoices = LOG_LEVELS.map(function(level) {
+        return new Render.SelectOption(level);
+    });
+
+    let inputFields = [
+        new Render.FieldType(context, 'level', 'Level', {
+            type: Render.INPUT_TYPE_SELECT,
+            choices: levelChoices,
+            defaultValue: 'INFO',
+        }),
+        new Render.FieldType(context, 'target-email', 'Target Email', {
+            type: Render.INPUT_TYPE_EMAIL,
+        }),
+        new Render.FieldType(context, 'target-course', 'Target Course'),
+        new Render.FieldType(context, 'target-assignment', 'Target Assignment'),
+        new Render.FieldType(context, 'after', 'After Timestamp'),
+        new Render.FieldType(context, 'past', 'Past Window', {
+            placeholder: 'Example: 24h',
+        }),
+    ];
+
+    Render.makePage(
+        params, context, container, queryLogs,
+        {
+            header: 'View Logs',
+            description: 'Query server logs by level and optional filters.',
+            inputs: inputFields,
+            buttonName: 'Query Logs',
+            iconName: Render.ICON_NAME_LIST,
+        },
+    );
+}
+
+function queryLogs(params, context, container, inputParams) {
+    return Autograder.Misc.callEndpoint({
+            targetEndpoint: 'logs/query',
+            params: inputParams,
+            clearContextUser: false,
+        })
+        .then(function(result) {
+            if (!result.success) {
+                return Render.autograderError(result?.error?.message ?? 'Failed to query logs.');
+            }
+
+            if (result.results.length === 0) {
+                return '<p>No logs matched your query.</p>';
+            }
+
+            Render.apiOutputSwitcher(result.results, container, {
+                renderOptions: new Render.APIValueRenderOptions({
+                    keyOrdering: ['timestamp', 'level', 'message', 'attributes'],
+                    initialIndentLevel: -1,
+                }),
+                modes: [
+                    Render.API_OUTPUT_SWITCHER_TEXT,
+                    Render.API_OUTPUT_SWITCHER_TABLE,
+                    Render.API_OUTPUT_SWITCHER_JSON,
+                ],
+            });
+
+            return undefined;
+        })
+        .catch(function(message) {
+            console.error(message);
+            return Render.autograderError(message);
+        })
+    ;
+}
+
+init();

--- a/site/js/modules/webui/server/logs.test.js
+++ b/site/js/modules/webui/server/logs.test.js
@@ -1,39 +1,14 @@
 import * as Core from '../core/index.js';
-import * as Render from '../render/index.js';
 import * as Test from '../test/index.js';
 
 test('Server Logs Query', async function() {
     await Test.loginUser('server-admin');
     await Test.navigate(Core.Routing.PATH_SERVER_LOGS);
 
-    Test.checkPageBasics('View Logs', 'view logs');
+    Test.checkPageBasics('View Server Logs', 'view server logs');
 
     await Test.submitTemplate();
 
     let results = document.querySelector('.results-area').innerHTML;
     expect(results).toContain('API Server Created.');
-});
-
-describe('Server Logs Query, Output Switching', function() {
-    // [[mode, prefix], ...]
-    const testCases = [
-        [Render.API_OUTPUT_SWITCHER_JSON, '"message": "'],
-        [Render.API_OUTPUT_SWITCHER_TABLE, '<td>'],
-        [Render.API_OUTPUT_SWITCHER_TEXT, 'Message: '],
-    ];
-
-    test.each(testCases)("%s", async function(mode, prefix) {
-        await Test.loginUser('server-admin');
-        await Test.navigate(Core.Routing.PATH_SERVER_LOGS);
-
-        Test.checkPageBasics('View Logs', 'view logs');
-
-        await Test.submitTemplate();
-
-        let button = document.querySelector(`.output-switcher .controls button.${mode.toLowerCase()}`);
-        button.click();
-
-        let results = document.querySelector('.results-area').innerHTML;
-        expect(results).toContain(prefix);
-    });
 });

--- a/site/js/modules/webui/server/logs.test.js
+++ b/site/js/modules/webui/server/logs.test.js
@@ -1,0 +1,39 @@
+import * as Core from '../core/index.js';
+import * as Render from '../render/index.js';
+import * as Test from '../test/index.js';
+
+test('Server Logs Query', async function() {
+    await Test.loginUser('server-admin');
+    await Test.navigate(Core.Routing.PATH_SERVER_LOGS);
+
+    Test.checkPageBasics('View Logs', 'view logs');
+
+    await Test.submitTemplate();
+
+    let results = document.querySelector('.results-area').innerHTML;
+    expect(results).toContain('API Server Created.');
+});
+
+describe('Server Logs Query, Output Switching', function() {
+    // [[mode, prefix], ...]
+    const testCases = [
+        [Render.API_OUTPUT_SWITCHER_JSON, '"message": "'],
+        [Render.API_OUTPUT_SWITCHER_TABLE, '<td>'],
+        [Render.API_OUTPUT_SWITCHER_TEXT, 'Message: '],
+    ];
+
+    test.each(testCases)("%s", async function(mode, prefix) {
+        await Test.loginUser('server-admin');
+        await Test.navigate(Core.Routing.PATH_SERVER_LOGS);
+
+        Test.checkPageBasics('View Logs', 'view logs');
+
+        await Test.submitTemplate();
+
+        let button = document.querySelector(`.output-switcher .controls button.${mode.toLowerCase()}`);
+        button.click();
+
+        let results = document.querySelector('.results-area').innerHTML;
+        expect(results).toContain(prefix);
+    });
+});

--- a/site/js/modules/webui/server/server.js
+++ b/site/js/modules/webui/server/server.js
@@ -16,7 +16,7 @@ function handlerServer(path, params, context, container) {
     let cards = [
         new Render.Card('server-action', 'API Documentation', Core.Routing.formHashPath(Core.Routing.PATH_SERVER_DOCS)),
         new Render.Card('server-action', 'Call API', Core.Routing.formHashPath(Core.Routing.PATH_SERVER_CALL_API, args)),
-        new Render.Card('server-action', 'View Logs', Core.Routing.formHashPath(Core.Routing.PATH_SERVER_LOGS, args)),
+        new Render.Card('server-action', 'View Server Logs', Core.Routing.formHashPath(Core.Routing.PATH_SERVER_LOGS, args)),
         new Render.Card('server-action', 'List Courses', Core.Routing.formHashPath(Core.Routing.PATH_SERVER_COURSES_LIST, args), {
             minServerRole: Autograder.Common.SERVER_ROLE_ADMIN,
         }),

--- a/site/js/modules/webui/server/server.js
+++ b/site/js/modules/webui/server/server.js
@@ -16,6 +16,7 @@ function handlerServer(path, params, context, container) {
     let cards = [
         new Render.Card('server-action', 'API Documentation', Core.Routing.formHashPath(Core.Routing.PATH_SERVER_DOCS)),
         new Render.Card('server-action', 'Call API', Core.Routing.formHashPath(Core.Routing.PATH_SERVER_CALL_API, args)),
+        new Render.Card('server-action', 'View Logs', Core.Routing.formHashPath(Core.Routing.PATH_SERVER_LOGS, args)),
         new Render.Card('server-action', 'List Courses', Core.Routing.formHashPath(Core.Routing.PATH_SERVER_COURSES_LIST, args), {
             minServerRole: Autograder.Common.SERVER_ROLE_ADMIN,
         }),

--- a/site/js/modules/webui/server/server.test.js
+++ b/site/js/modules/webui/server/server.test.js
@@ -9,7 +9,7 @@ describe('Nav Server Actions', function() {
             [
                 'API Documentation',
                 'Call API',
-                'View Logs',
+                'View Server Logs',
             ],
         ],
         [
@@ -17,7 +17,7 @@ describe('Nav Server Actions', function() {
             [
                 'API Documentation',
                 'Call API',
-                'View Logs',
+                'View Server Logs',
             ],
         ],
         [
@@ -27,7 +27,7 @@ describe('Nav Server Actions', function() {
                 'Call API',
                 'List Courses',
                 'List Users',
-                'View Logs',
+                'View Server Logs',
             ],
         ],
     ];

--- a/site/js/modules/webui/server/server.test.js
+++ b/site/js/modules/webui/server/server.test.js
@@ -9,6 +9,7 @@ describe('Nav Server Actions', function() {
             [
                 'API Documentation',
                 'Call API',
+                'View Logs',
             ],
         ],
         [
@@ -16,6 +17,7 @@ describe('Nav Server Actions', function() {
             [
                 'API Documentation',
                 'Call API',
+                'View Logs',
             ],
         ],
         [
@@ -25,6 +27,7 @@ describe('Nav Server Actions', function() {
                 'Call API',
                 'List Courses',
                 'List Users',
+                'View Logs',
             ],
         ],
     ];


### PR DESCRIPTION
## Summary
- add a new server/logs route and **View Logs** card in Server Actions
- add a logs query page that calls logs/query with common filters (level, 	arget-email, 	arget-course, 	arget-assignment, fter, past)
- render log results with text/table/json output switcher
- add Jest coverage for navigation and logs rendering/output switching

## Testing
- npm test -- site/js/modules/webui/server/server.test.js site/js/modules/webui/server/logs.test.js site/js/modules/webui/server/users.test.js

Refs edulinq/autograder-server#61