### PR TITLE
Add Code Analysis GUI visual rendering (Issue #142)

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1296,6 +1296,15 @@ table.standard-table tr:not(:last-child) {
     background-color: #f44336;
 }
 
+.analysis-loc-header {
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+}
+
+.pairwise-overall-summary {
+    margin-bottom: 1em;
+}
+
 details.raw-json-fallback {
     margin-top: 1.5em;
 }
@@ -1315,11 +1324,6 @@ details.raw-json-fallback pre {
     margin-top: 0.5em;
     overflow-x: auto;
     font-size: var(--font-size-smaller);
-}
-
-table.analysis-summary-table th.label {
-    text-align: left;
-    font-weight: var(--font-weight-bold);
 }
 
 table.analysis-results-table td,

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1239,8 +1239,6 @@ table.standard-table tr:not(:last-child) {
     align-items: center;
 }
 
-/* ===== Code Analysis GUI (Issue #142) ===== */
-
 .analysis-section {
     margin-bottom: 1.5em;
 }
@@ -1257,43 +1255,6 @@ table.standard-table tr:not(:last-child) {
 
 .analysis-pending {
     color: var(--color-text-secondary-low);
-    font-style: italic;
-    margin-left: 1em;
-}
-
-.score-bar-container {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 0.5em;
-    min-width: 130px;
-}
-
-.score-bar-track {
-    flex-grow: 1;
-    height: 0.6em;
-    background-color: var(--color-bg-secondary-low);
-    border-radius: var(--curve-radius-large);
-    overflow: hidden;
-}
-
-.score-bar-fill {
-    height: 100%;
-    background-color: var(--color-bg-accent-primary);
-    border-radius: var(--curve-radius-large);
-    transition: width 0.3s ease;
-}
-
-.score-bar-fill.similarity-low {
-    background-color: #4caf50;
-}
-
-.score-bar-fill.similarity-mid {
-    background-color: #ff9800;
-}
-
-.score-bar-fill.similarity-high {
-    background-color: #f44336;
 }
 
 .analysis-loc-header {
@@ -1305,28 +1266,16 @@ table.standard-table tr:not(:last-child) {
     margin-bottom: 1em;
 }
 
-details.raw-json-fallback {
+.analysis-raw-json {
     margin-top: 1.5em;
 }
 
-details.raw-json-fallback summary {
+.analysis-raw-json summary {
     cursor: pointer;
     color: var(--color-text-secondary-low);
     font-size: var(--font-size-smaller);
-    user-select: none;
 }
 
-details.raw-json-fallback summary:hover {
+.analysis-raw-json summary:hover {
     color: var(--color-text-secondary);
-}
-
-details.raw-json-fallback pre {
-    margin-top: 0.5em;
-    overflow-x: auto;
-    font-size: var(--font-size-smaller);
-}
-
-table.analysis-results-table td,
-table.pairwise-pairs-table td {
-    vertical-align: middle;
 }

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1238,3 +1238,91 @@ table.standard-table tr:not(:last-child) {
     justify-content: space-evenly;
     align-items: center;
 }
+
+/* ===== Code Analysis GUI (Issue #142) ===== */
+
+.analysis-section {
+    margin-bottom: 1.5em;
+}
+
+.analysis-section h3 {
+    margin-bottom: 0.75em;
+    padding-bottom: 0.25em;
+    border-bottom: 1px solid var(--color-text-secondary);
+}
+
+.analysis-section h4 {
+    margin-bottom: 0.5em;
+}
+
+.analysis-pending {
+    color: var(--color-text-secondary-low);
+    font-style: italic;
+    margin-left: 1em;
+}
+
+.score-bar-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5em;
+    min-width: 130px;
+}
+
+.score-bar-track {
+    flex-grow: 1;
+    height: 0.6em;
+    background-color: var(--color-bg-secondary-low);
+    border-radius: var(--curve-radius-large);
+    overflow: hidden;
+}
+
+.score-bar-fill {
+    height: 100%;
+    background-color: var(--color-bg-accent-primary);
+    border-radius: var(--curve-radius-large);
+    transition: width 0.3s ease;
+}
+
+.score-bar-fill.similarity-low {
+    background-color: #4caf50;
+}
+
+.score-bar-fill.similarity-mid {
+    background-color: #ff9800;
+}
+
+.score-bar-fill.similarity-high {
+    background-color: #f44336;
+}
+
+details.raw-json-fallback {
+    margin-top: 1.5em;
+}
+
+details.raw-json-fallback summary {
+    cursor: pointer;
+    color: var(--color-text-secondary-low);
+    font-size: var(--font-size-smaller);
+    user-select: none;
+}
+
+details.raw-json-fallback summary:hover {
+    color: var(--color-text-secondary);
+}
+
+details.raw-json-fallback pre {
+    margin-top: 0.5em;
+    overflow-x: auto;
+    font-size: var(--font-size-smaller);
+}
+
+table.analysis-summary-table th.label {
+    text-align: left;
+    font-weight: var(--font-weight-bold);
+}
+
+table.analysis-results-table td,
+table.pairwise-pairs-table td {
+    vertical-align: middle;
+}

--- a/site/js/modules/webui/courses/assignment/analysis/individual.js
+++ b/site/js/modules/webui/courses/assignment/analysis/individual.js
@@ -47,7 +47,7 @@ function analysisIndividual(params, context, container, inputParams) {
             inputParams.wait, inputParams.dryRun,
         )
         .then(function(result) {
-            return Render.codeBlockJSON(result);
+            return Render.renderIndividualAnalysis(result);
         })
         .catch(function(message) {
             console.error(message);

--- a/site/js/modules/webui/courses/assignment/analysis/individual.test.js
+++ b/site/js/modules/webui/courses/assignment/analysis/individual.test.js
@@ -21,8 +21,12 @@ test('Individual Analysis', async function() {
 
     await Test.submitTemplate();
 
-    let results = document.querySelector('.results-area').innerHTML;
-    expect(results).toContain('"complete": true');
-    expect(results).toContain('"pending-count": 0');
-    expect(results).toContain('"overwrite-records": true');
+    let resultsArea = document.querySelector('.results-area');
+
+    // DOM-based structural assertions.
+    expect(resultsArea.querySelector('.analysis-section')).not.toBeNull();
+    expect(resultsArea.querySelector('.analysis-summary-table')).not.toBeNull();
+    expect(resultsArea.querySelector('.analysis-results-table')).not.toBeNull();
+    expect(resultsArea.querySelector('details.raw-json-fallback')).not.toBeNull();
+    expect(resultsArea.querySelector('details.raw-json-fallback summary').textContent).toContain('Raw JSON');
 });

--- a/site/js/modules/webui/courses/assignment/analysis/individual.test.js
+++ b/site/js/modules/webui/courses/assignment/analysis/individual.test.js
@@ -27,6 +27,6 @@ test('Individual Analysis', async function() {
     expect(resultsArea.querySelector('.analysis-section')).not.toBeNull();
     expect(resultsArea.querySelector('.analysis-summary-table')).not.toBeNull();
     expect(resultsArea.querySelector('.analysis-results-table')).not.toBeNull();
-    expect(resultsArea.querySelector('details.raw-json-fallback')).not.toBeNull();
-    expect(resultsArea.querySelector('details.raw-json-fallback summary').textContent).toContain('Raw JSON');
+    expect(resultsArea.querySelector('details.analysis-raw-json')).not.toBeNull();
+    expect(resultsArea.querySelector('details.analysis-raw-json summary').textContent).toContain('Raw JSON');
 });

--- a/site/js/modules/webui/courses/assignment/analysis/pairwise.js
+++ b/site/js/modules/webui/courses/assignment/analysis/pairwise.js
@@ -47,7 +47,7 @@ function analysisPairwise(params, context, container, inputParams) {
             inputParams.wait, inputParams.dryRun,
         )
         .then(function(result) {
-            return Render.codeBlockJSON(result);
+            return Render.renderPairwiseAnalysis(result);
         })
         .catch(function(message) {
             console.error(message);

--- a/site/js/modules/webui/courses/assignment/analysis/pairwise.test.js
+++ b/site/js/modules/webui/courses/assignment/analysis/pairwise.test.js
@@ -21,9 +21,12 @@ test('Pairwise Analysis', async function() {
 
     await Test.submitTemplate();
 
-    let results = document.querySelector('.results-area').innerHTML;
-    expect(results).toContain('similarities');
-    expect(results).toContain('"complete": true');
-    expect(results).toContain('"pending-count": 0');
-    expect(results).toContain('"overwrite-records": true');
+    let resultsArea = document.querySelector('.results-area');
+
+    // DOM-based structural assertions.
+    expect(resultsArea.querySelector('.analysis-section')).not.toBeNull();
+    expect(resultsArea.querySelector('.pairwise-summary')).not.toBeNull();
+    expect(resultsArea.querySelector('.pairwise-pairs-table')).not.toBeNull();
+    expect(resultsArea.querySelector('details.raw-json-fallback')).not.toBeNull();
+    expect(resultsArea.querySelector('details.raw-json-fallback summary').textContent).toContain('Raw JSON');
 });

--- a/site/js/modules/webui/courses/assignment/analysis/pairwise.test.js
+++ b/site/js/modules/webui/courses/assignment/analysis/pairwise.test.js
@@ -27,6 +27,6 @@ test('Pairwise Analysis', async function() {
     expect(resultsArea.querySelector('.analysis-section')).not.toBeNull();
     expect(resultsArea.querySelector('.pairwise-summary')).not.toBeNull();
     expect(resultsArea.querySelector('.pairwise-pairs-table')).not.toBeNull();
-    expect(resultsArea.querySelector('details.raw-json-fallback')).not.toBeNull();
-    expect(resultsArea.querySelector('details.raw-json-fallback summary').textContent).toContain('Raw JSON');
+    expect(resultsArea.querySelector('details.analysis-raw-json')).not.toBeNull();
+    expect(resultsArea.querySelector('details.analysis-raw-json summary').textContent).toContain('Raw JSON');
 });

--- a/site/js/modules/webui/render/analysis.js
+++ b/site/js/modules/webui/render/analysis.js
@@ -1,21 +1,6 @@
-import { tableFromLists } from './table.js';
-
-// Shared render helpers for code analysis result visualizations.
-// Used by both individual.js and pairwise.js.
-
-// Utility helpers.
-
-function escapeHTML(str) {
-    if (str === null || str === undefined) {
-        return '';
-    }
-    return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;');
-}
+import * as RenderJSON from './json.js';
+import * as Table from './table.js';
+import * as Util from '../util/index.js';
 
 function formatNumber(value, decimalPlaces = 2) {
     if (value === null || value === undefined) {
@@ -46,48 +31,7 @@ function msToSeconds(ms) {
     return formatNumber(ms / 1000) + 's';
 }
 
-// Visual render helpers.
-
-// Renders a horizontal progress bar.
-// maxValue should come from summary aggregate max -- never hardcoded.
-function scoreBar(value, maxValue) {
-    if (value === null || value === undefined || !maxValue || maxValue === 0) {
-        return `<span>-</span>`;
-    }
-    const pct = Math.min(100, (value / maxValue) * 100).toFixed(1);
-    return `
-        <div class='score-bar-container'>
-            <div class='score-bar-track'>
-                <div class='score-bar-fill' style='width:${pct}%'></div>
-            </div>
-            <span>${formatNumber(value)}</span>
-        </div>
-    `;
-}
-
-// Renders a colored similarity bar: green (low) / orange (mid) / red (high).
-function similarityBar(score) {
-    if (score === null || score === undefined) {
-        return `<span>-</span>`;
-    }
-    let cls = 'similarity-low';
-    if (score >= 0.5) {
-        cls = 'similarity-high';
-    } else if (score >= 0.2) {
-        cls = 'similarity-mid';
-    }
-    const pct = Math.min(100, score * 100).toFixed(1);
-    return `
-        <div class='score-bar-container'>
-            <div class='score-bar-track'>
-                <div class='score-bar-fill ${cls}' style='width:${pct}%'></div>
-            </div>
-            <span>${formatPercent(score)}</span>
-        </div>
-    `;
-}
-
-// Converts an aggregate object to an array of formatted strings for tableFromLists.
+// Converts an aggregate object to an array of formatted strings for Table.tableFromLists.
 function aggregateToRow(aggregate) {
     if (!aggregate) {
         return ['-', '-', '-', '-', '-'];
@@ -101,33 +45,20 @@ function aggregateToRow(aggregate) {
     ];
 }
 
-// Returns styled pending/empty state paragraph.
+// Returns a pending/empty state paragraph.
 function pendingState(message = 'Data pending or unavailable.') {
-    return `<p class='analysis-pending'>${escapeHTML(message)}</p>`;
+    return `<p class='analysis-pending'>${Util.escapeHTML(message)}</p>`;
 }
 
 // Wraps content in a titled analysis section block.
 function analysisSection(title, bodyHTML) {
     return `
         <div class='analysis-section'>
-            <h3>${escapeHTML(title)}</h3>
+            <h3>${Util.escapeHTML(title)}</h3>
             ${bodyHTML}
         </div>
     `;
 }
-
-// Collapsible raw JSON fallback for debugging.
-function rawJsonFallback(result) {
-    const json = JSON.stringify(result, null, 4);
-    return `
-        <details class='raw-json-fallback'>
-            <summary>Raw JSON</summary>
-            <pre class='code-block'>${escapeHTML(json)}</pre>
-        </details>
-    `;
-}
-
-// Individual analysis sections.
 
 function renderIndividualAnalysis(result) {
     const summary = result['summary'];
@@ -136,7 +67,6 @@ function renderIndividualAnalysis(result) {
 
     let html = '';
 
-    // Pending banner.
     if (!isComplete) {
         html += `<p class='analysis-pending'>Analysis is still running. Showing partial data.</p>`;
     }
@@ -144,35 +74,43 @@ function renderIndividualAnalysis(result) {
     // Summary stats.
     const headers = ['Metric', 'Count', 'Mean', 'Median', 'Min', 'Max'];
     const summaryItems = [
-        ['Score',         summary['aggregate-score']],
+        ['Score', summary['aggregate-score']],
         ['Lines of Code', summary['aggregate-lines-of-code']],
-        ['Time Delta',    summary['aggregate-submission-time-delta']],
-        ['LOC Delta',     summary['aggregate-lines-of-code-delta']],
-        ['Score Delta',   summary['aggregate-score-delta']],
-        ['LOC / hr (Velocity)',   summary['aggregate-lines-of-code-per-hour']],
+        ['Time Delta', summary['aggregate-submission-time-delta']],
+        ['LOC Delta', summary['aggregate-lines-of-code-delta']],
+        ['Score Delta', summary['aggregate-score-delta']],
+        ['LOC / hr (Velocity)', summary['aggregate-lines-of-code-per-hour']],
         ['Score / hr (Velocity)', summary['aggregate-score-per-hour']],
     ];
 
-    const summaryRows = summaryItems.map(function(item) {
-        const row = [escapeHTML(item[0])];
-        return row.concat(aggregateToRow(item[1]));
-    });
+    let summaryRows = [];
+    for (const item of summaryItems) {
+        let row = [Util.escapeHTML(item[0])];
+        for (const cell of aggregateToRow(item[1])) {
+            row.push(cell);
+        }
+        summaryRows.push(row);
+    }
 
-    let summaryHTML = tableFromLists(headers, summaryRows, ['analysis-summary-table']);
+    let summaryHTML = Table.tableFromLists(headers, summaryRows, ['analysis-summary-table']);
 
     // Per-file LOC sub-table.
     const locPerFile = summary['aggregate-lines-of-code-per-file'];
     if (locPerFile) {
         const fileNames = Object.keys(locPerFile).sort();
-        const fileRows = fileNames.map(function(filename) {
-            const row = [escapeHTML(filename)];
-            return row.concat(aggregateToRow(locPerFile[filename]));
-        });
-
         const fileHeaders = ['File', 'Count', 'Mean', 'Median', 'Min', 'Max'];
+        let fileRows = [];
+        for (const filename of fileNames) {
+            let row = [Util.escapeHTML(filename)];
+            for (const cell of aggregateToRow(locPerFile[filename])) {
+                row.push(cell);
+            }
+            fileRows.push(row);
+        }
+
         summaryHTML += `
             <h4 class='analysis-loc-header'>Lines of Code per File</h4>
-            ${tableFromLists(fileHeaders, fileRows, ['analysis-loc-per-file-table'])}
+            ${Table.tableFromLists(fileHeaders, fileRows, ['analysis-loc-per-file-table'])}
         `;
     } else {
         summaryHTML += pendingState('Per-file LOC breakdown not yet available.');
@@ -181,7 +119,6 @@ function renderIndividualAnalysis(result) {
     html += analysisSection('Summary Statistics', summaryHTML);
 
     // Per-submission table.
-    const dynamicMax = summary['aggregate-score']?.['max'] ?? 1;
     const submissionIDs = Object.keys(results).sort();
 
     let resultsHTML = '';
@@ -195,32 +132,34 @@ function renderIndividualAnalysis(result) {
 
         const rows = submissionIDs.map(function(id) {
             const r = results[id];
-            const shortId = escapeHTML(r['short-id'] ?? id);
+            const shortId = Util.escapeHTML(r['short-id'] ?? id);
 
             return [
-                `<span title='${escapeHTML(id)}'>${shortId}</span>`,
-                scoreBar(r['score'] ?? null, dynamicMax),
+                shortId,
+                formatNumber(r['score'] ?? null),
                 formatNumber(r['lines-of-code'] ?? null, 0),
                 msToSeconds(r['submission-time-delta'] ?? null),
                 formatNumber(r['lines-of-code-delta'] ?? null, 0),
                 formatNumber(r['score-delta'] ?? null),
                 formatNumber(r['lines-of-code-per-hour'] ?? null),
-                formatNumber(r['score-per-hour'] ?? null)
+                formatNumber(r['score-per-hour'] ?? null),
             ];
         });
 
-        resultsHTML = tableFromLists(resHeaders, rows, ['analysis-results-table']);
+        resultsHTML = Table.tableFromLists(resHeaders, rows, ['analysis-results-table']);
     }
 
     html += analysisSection('Per-Submission Results', resultsHTML);
 
-    // Raw JSON fallback.
-    html += rawJsonFallback(result);
+    html += `
+        <details class='analysis-raw-json'>
+            <summary>Raw JSON</summary>
+            ${RenderJSON.codeBlockJSON(result)}
+        </details>
+    `;
 
     return html;
 }
-
-// Pairwise analysis sections.
 
 function renderPairwiseAnalysis(result) {
     const summary = result['summary'];
@@ -238,7 +177,7 @@ function renderPairwiseAnalysis(result) {
     let summaryHTML = `
         <div class='pairwise-overall-summary'>
             <strong>Overall Mean Similarity:</strong>
-            ${similarityBar(totalMean?.['mean'] ?? null)}
+            ${formatPercent(totalMean?.['mean'] ?? null)}
         </div>
     `;
 
@@ -247,12 +186,16 @@ function renderPairwiseAnalysis(result) {
         const fileNames = Object.keys(meanSims).sort();
         const headers = ['File', 'Count', 'Mean', 'Median', 'Min', 'Max'];
 
-        const fileRows = fileNames.map(function(filename) {
-            const row = [escapeHTML(filename)];
-            return row.concat(aggregateToRow(meanSims[filename]));
-        });
+        let fileRows = [];
+        for (const filename of fileNames) {
+            let row = [Util.escapeHTML(filename)];
+            for (const cell of aggregateToRow(meanSims[filename])) {
+                row.push(cell);
+            }
+            fileRows.push(row);
+        }
 
-        summaryHTML += tableFromLists(headers, fileRows, ['pairwise-summary']);
+        summaryHTML += Table.tableFromLists(headers, fileRows, ['pairwise-summary']);
     } else {
         summaryHTML += pendingState('Per-file similarity summary not yet available.');
     }
@@ -269,8 +212,7 @@ function renderPairwiseAnalysis(result) {
         const resHeaders = ['Pair (short IDs)', 'File', 'Tool', 'Similarity'];
         let rows = [];
 
-        for (let i = 0; i < pairKeys.length; i++) {
-            const pairKey = pairKeys[i];
+        for (const pairKey of pairKeys) {
             const pair = results[pairKey];
             const sims = pair['similarities'] ?? {};
             const fileNames = Object.keys(sims).sort();
@@ -282,58 +224,50 @@ function renderPairwiseAnalysis(result) {
                 return segs[segs.length - 1] ?? p;
             }).join(' || ');
 
-            const shortSpan = `<span title='${escapeHTML(pairKey)}'>${escapeHTML(shortDisplay)}</span>`;
+            const shortSpan = Util.escapeHTML(shortDisplay);
 
             let pairHasRows = false;
-            for (let j = 0; j < fileNames.length; j++) {
-                const filename = fileNames[j];
+            for (const filename of fileNames) {
                 const toolEntries = sims[filename] ?? [];
 
-                for (let k = 0; k < toolEntries.length; k++) {
-                    const entry = toolEntries[k];
+                for (const entry of toolEntries) {
                     rows.push([
                         shortSpan,
-                        escapeHTML(filename),
-                        escapeHTML(entry['tool'] ?? '-'),
-                        similarityBar(entry['score'] ?? null)
+                        Util.escapeHTML(filename),
+                        Util.escapeHTML(entry['tool'] ?? '-'),
+                        formatPercent(entry['score'] ?? null),
                     ]);
                     pairHasRows = true;
                 }
             }
 
-            // Fallback: no files at all, OR files exist but all tool entry arrays were empty.
+            // Fallback: no files at all, or files exist but all tool entry arrays were empty.
             if (!pairHasRows) {
                 rows.push([
                     shortSpan,
                     pendingState('No tool results available.'),
                     '-',
-                    '-'
+                    '-',
                 ]);
             }
         }
 
-        pairsHTML = tableFromLists(resHeaders, rows, ['pairwise-pairs-table']);
+        pairsHTML = Table.tableFromLists(resHeaders, rows, ['pairwise-pairs-table']);
     }
 
     html += analysisSection('Per-Pair Comparisons', pairsHTML);
 
-    // Raw JSON fallback.
-    html += rawJsonFallback(result);
+    html += `
+        <details class='analysis-raw-json'>
+            <summary>Raw JSON</summary>
+            ${RenderJSON.codeBlockJSON(result)}
+        </details>
+    `;
 
     return html;
 }
 
 export {
-    escapeHTML,
-    formatNumber,
-    formatPercent,
-    msToSeconds,
-    scoreBar,
-    similarityBar,
-    aggregateToRow,
-    pendingState,
-    analysisSection,
-    rawJsonFallback,
     renderIndividualAnalysis,
     renderPairwiseAnalysis,
 };

--- a/site/js/modules/webui/render/analysis.js
+++ b/site/js/modules/webui/render/analysis.js
@@ -32,7 +32,11 @@ function formatPercent(value) {
     if (value === null || value === undefined) {
         return '-';
     }
-    return formatNumber(value * 100, 1) + '%';
+    const formatted = formatNumber(value * 100, 1);
+    if (formatted === '-') {
+        return '-';
+    }
+    return formatted + '%';
 }
 
 function msToSeconds(ms) {
@@ -45,7 +49,7 @@ function msToSeconds(ms) {
 // Visual render helpers.
 
 // Renders a horizontal progress bar.
-// maxValue should come from summary aggregate max — never hardcoded.
+// maxValue should come from summary aggregate max -- never hardcoded.
 function scoreBar(value, maxValue) {
     if (value === null || value === undefined || !maxValue || maxValue === 0) {
         return `<span>-</span>`;
@@ -242,7 +246,7 @@ function renderPairwiseAnalysis(result) {
     if (meanSims) {
         const fileNames = Object.keys(meanSims).sort();
         const headers = ['File', 'Count', 'Mean', 'Median', 'Min', 'Max'];
-        
+
         const fileRows = fileNames.map(function(filename) {
             const row = [escapeHTML(filename)];
             return row.concat(aggregateToRow(meanSims[filename]));
@@ -271,7 +275,7 @@ function renderPairwiseAnalysis(result) {
             const sims = pair['similarities'] ?? {};
             const fileNames = Object.keys(sims).sort();
 
-            // Shorten pair key for display — keep only short IDs.
+            // Shorten pair key for display -- keep only short IDs.
             const parts = pairKey.split('||');
             const shortDisplay = parts.map(function(p) {
                 const segs = p.split('::');
@@ -284,7 +288,7 @@ function renderPairwiseAnalysis(result) {
             for (let j = 0; j < fileNames.length; j++) {
                 const filename = fileNames[j];
                 const toolEntries = sims[filename] ?? [];
-                
+
                 for (let k = 0; k < toolEntries.length; k++) {
                     const entry = toolEntries[k];
                     rows.push([

--- a/site/js/modules/webui/render/analysis.js
+++ b/site/js/modules/webui/render/analysis.js
@@ -1,7 +1,9 @@
+import { tableFromLists } from './table.js';
+
 // Shared render helpers for code analysis result visualizations.
 // Used by both individual.js and pairwise.js.
 
-// ─── Utility Helpers ────────────────────────────────────────────────────────
+// Utility helpers.
 
 function escapeHTML(str) {
     if (str === null || str === undefined) {
@@ -40,7 +42,7 @@ function msToSeconds(ms) {
     return formatNumber(ms / 1000) + 's';
 }
 
-// ─── Visual Render Helpers ───────────────────────────────────────────────────
+// Visual render helpers.
 
 // Renders a horizontal progress bar.
 // maxValue should come from summary aggregate max — never hardcoded.
@@ -81,18 +83,18 @@ function similarityBar(score) {
     `;
 }
 
-// Renders cells: count | mean | median | min | max from an aggregate object.
-function aggregateCells(aggregate) {
+// Converts an aggregate object to an array of formatted strings for tableFromLists.
+function aggregateToRow(aggregate) {
     if (!aggregate) {
-        return `<td colspan='5'>-</td>`;
+        return ['-', '-', '-', '-', '-'];
     }
-    return `
-        <td>${formatNumber(aggregate['count'], 0)}</td>
-        <td>${formatNumber(aggregate['mean'])}</td>
-        <td>${formatNumber(aggregate['median'])}</td>
-        <td>${formatNumber(aggregate['min'])}</td>
-        <td>${formatNumber(aggregate['max'])}</td>
-    `;
+    return [
+        formatNumber(aggregate['count'], 0),
+        formatNumber(aggregate['mean']),
+        formatNumber(aggregate['median']),
+        formatNumber(aggregate['min']),
+        formatNumber(aggregate['max']),
+    ];
 }
 
 // Returns styled pending/empty state paragraph.
@@ -121,7 +123,7 @@ function rawJsonFallback(result) {
     `;
 }
 
-// ─── Individual Analysis Sections ────────────────────────────────────────────
+// Individual analysis sections.
 
 function renderIndividualAnalysis(result) {
     const summary = result['summary'];
@@ -132,22 +134,12 @@ function renderIndividualAnalysis(result) {
 
     // Pending banner.
     if (!isComplete) {
-        html += `<p class='analysis-pending'>⏳ Analysis is still running. Showing partial data.</p>`;
+        html += `<p class='analysis-pending'>Analysis is still running. Showing partial data.</p>`;
     }
 
-    // --- Section A: Summary Stats ---
-    const aggregateHeaders = `
-        <tr>
-            <th>Metric</th>
-            <th>Count</th>
-            <th>Mean</th>
-            <th>Median</th>
-            <th>Min</th>
-            <th>Max</th>
-        </tr>
-    `;
-
-    const summaryRows = [
+    // Summary stats.
+    const headers = ['Metric', 'Count', 'Mean', 'Median', 'Min', 'Max'];
+    const summaryItems = [
         ['Score',         summary['aggregate-score']],
         ['Lines of Code', summary['aggregate-lines-of-code']],
         ['Time Delta',    summary['aggregate-submission-time-delta']],
@@ -155,40 +147,28 @@ function renderIndividualAnalysis(result) {
         ['Score Delta',   summary['aggregate-score-delta']],
         ['LOC / hr (Velocity)',   summary['aggregate-lines-of-code-per-hour']],
         ['Score / hr (Velocity)', summary['aggregate-score-per-hour']],
-    ].map(([label, agg]) => `
-        <tr>
-            <th class='label'>${escapeHTML(label)}</th>
-            ${aggregateCells(agg)}
-        </tr>
-    `).join('');
+    ];
 
-    let summaryHTML = `
-        <table class='standard-table analysis-summary-table'>
-            <thead>${aggregateHeaders}</thead>
-            <tbody>${summaryRows}</tbody>
-        </table>
-    `;
+    const summaryRows = summaryItems.map(function(item) {
+        const row = [escapeHTML(item[0])];
+        return row.concat(aggregateToRow(item[1]));
+    });
+
+    let summaryHTML = tableFromLists(headers, summaryRows, ['analysis-summary-table']);
 
     // Per-file LOC sub-table.
     const locPerFile = summary['aggregate-lines-of-code-per-file'];
     if (locPerFile) {
-        const fileRows = Object.keys(locPerFile).sort().map((filename) => `
-            <tr>
-                <td>${escapeHTML(filename)}</td>
-                ${aggregateCells(locPerFile[filename])}
-            </tr>
-        `).join('');
+        const fileNames = Object.keys(locPerFile).sort();
+        const fileRows = fileNames.map(function(filename) {
+            const row = [escapeHTML(filename)];
+            return row.concat(aggregateToRow(locPerFile[filename]));
+        });
 
+        const fileHeaders = ['File', 'Count', 'Mean', 'Median', 'Min', 'Max'];
         summaryHTML += `
-            <h4 style='margin-top:1em;margin-bottom:0.5em;'>Lines of Code per File</h4>
-            <table class='standard-table analysis-loc-per-file-table'>
-                <thead>
-                    <tr>
-                        <th>File</th><th>Count</th><th>Mean</th><th>Median</th><th>Min</th><th>Max</th>
-                    </tr>
-                </thead>
-                <tbody>${fileRows}</tbody>
-            </table>
+            <h4 class='analysis-loc-header'>Lines of Code per File</h4>
+            ${tableFromLists(fileHeaders, fileRows, ['analysis-loc-per-file-table'])}
         `;
     } else {
         summaryHTML += pendingState('Per-file LOC breakdown not yet available.');
@@ -196,7 +176,7 @@ function renderIndividualAnalysis(result) {
 
     html += analysisSection('Summary Statistics', summaryHTML);
 
-    // --- Section B: Per-Submission Table ---
+    // Per-submission table.
     const dynamicMax = summary['aggregate-score']?.['max'] ?? 1;
     const submissionIDs = Object.keys(results).sort();
 
@@ -204,58 +184,39 @@ function renderIndividualAnalysis(result) {
     if (submissionIDs.length === 0) {
         resultsHTML = pendingState('No individual results yet.');
     } else {
-        const rows = submissionIDs.map((id) => {
+        const resHeaders = [
+            'Submission ID', 'Score', 'LOC', 'Time Delta', 'LOC Delta',
+            'Score Delta', 'LOC / hr', 'Score / hr'
+        ];
+
+        const rows = submissionIDs.map(function(id) {
             const r = results[id];
-            const score      = r['score']                 ?? null;
-            const loc        = r['lines-of-code']         ?? null;
-            const timeDelta  = r['submission-time-delta'] ?? null;
-            const locDelta   = r['lines-of-code-delta']   ?? null;
-            const scoreDelta = r['score-delta']           ?? null;
-            const locPerHr   = r['lines-of-code-per-hour'] ?? null;
-            const scorePerHr = r['score-per-hour']        ?? null;
+            const shortId = escapeHTML(r['short-id'] ?? id);
 
-            return `
-                <tr>
-                    <td title='${escapeHTML(id)}'>${escapeHTML(r['short-id'] ?? id)}</td>
-                    <td>${scoreBar(score, dynamicMax)}</td>
-                    <td>${formatNumber(loc, 0)}</td>
-                    <td>${msToSeconds(timeDelta)}</td>
-                    <td>${formatNumber(locDelta, 0)}</td>
-                    <td>${formatNumber(scoreDelta)}</td>
-                    <td>${formatNumber(locPerHr)}</td>
-                    <td>${formatNumber(scorePerHr)}</td>
-                </tr>
-            `;
-        }).join('');
+            return [
+                `<span title='${escapeHTML(id)}'>${shortId}</span>`,
+                scoreBar(r['score'] ?? null, dynamicMax),
+                formatNumber(r['lines-of-code'] ?? null, 0),
+                msToSeconds(r['submission-time-delta'] ?? null),
+                formatNumber(r['lines-of-code-delta'] ?? null, 0),
+                formatNumber(r['score-delta'] ?? null),
+                formatNumber(r['lines-of-code-per-hour'] ?? null),
+                formatNumber(r['score-per-hour'] ?? null)
+            ];
+        });
 
-        resultsHTML = `
-            <table class='standard-table analysis-results-table'>
-                <thead>
-                    <tr>
-                        <th>Submission ID</th>
-                        <th>Score</th>
-                        <th>LOC</th>
-                        <th>Time Δ</th>
-                        <th>LOC Δ</th>
-                        <th>Score Δ</th>
-                        <th>LOC / hr</th>
-                        <th>Score / hr</th>
-                    </tr>
-                </thead>
-                <tbody>${rows}</tbody>
-            </table>
-        `;
+        resultsHTML = tableFromLists(resHeaders, rows, ['analysis-results-table']);
     }
 
     html += analysisSection('Per-Submission Results', resultsHTML);
 
-    // --- Raw JSON Fallback ---
+    // Raw JSON fallback.
     html += rawJsonFallback(result);
 
     return html;
 }
 
-// ─── Pairwise Analysis Sections ──────────────────────────────────────────────
+// Pairwise analysis sections.
 
 function renderPairwiseAnalysis(result) {
     const summary = result['summary'];
@@ -265,13 +226,13 @@ function renderPairwiseAnalysis(result) {
     let html = '';
 
     if (!isComplete) {
-        html += `<p class='analysis-pending'>⏳ Analysis is still running. Showing partial data.</p>`;
+        html += `<p class='analysis-pending'>Analysis is still running. Showing partial data.</p>`;
     }
 
-    // --- Section A: Summary ---
+    // Similarity summary.
     const totalMean = summary['aggregate-total-mean-similarity'];
     let summaryHTML = `
-        <div style='margin-bottom:1em;'>
+        <div class='pairwise-overall-summary'>
             <strong>Overall Mean Similarity:</strong>
             ${similarityBar(totalMean?.['mean'] ?? null)}
         </div>
@@ -279,95 +240,80 @@ function renderPairwiseAnalysis(result) {
 
     const meanSims = summary['aggregate-mean-similarities'];
     if (meanSims) {
-        const fileRows = Object.keys(meanSims).sort().map((filename) => `
-            <tr>
-                <td>${escapeHTML(filename)}</td>
-                ${aggregateCells(meanSims[filename])}
-            </tr>
-        `).join('');
+        const fileNames = Object.keys(meanSims).sort();
+        const headers = ['File', 'Count', 'Mean', 'Median', 'Min', 'Max'];
+        
+        const fileRows = fileNames.map(function(filename) {
+            const row = [escapeHTML(filename)];
+            return row.concat(aggregateToRow(meanSims[filename]));
+        });
 
-        summaryHTML += `
-            <table class='standard-table pairwise-summary'>
-                <thead>
-                    <tr>
-                        <th>File</th><th>Count</th><th>Mean</th><th>Median</th><th>Min</th><th>Max</th>
-                    </tr>
-                </thead>
-                <tbody>${fileRows}</tbody>
-            </table>
-        `;
+        summaryHTML += tableFromLists(headers, fileRows, ['pairwise-summary']);
     } else {
         summaryHTML += pendingState('Per-file similarity summary not yet available.');
     }
 
     html += analysisSection('Similarity Summary', summaryHTML);
 
-    // --- Section B: Per-Pair Flattened Table ---
+    // Per-pair flattened table.
     const pairKeys = Object.keys(results).sort();
     let pairsHTML = '';
 
     if (pairKeys.length === 0) {
         pairsHTML = pendingState('No pairwise results yet.');
     } else {
-        let rows = '';
-        for (const pairKey of pairKeys) {
+        const resHeaders = ['Pair (short IDs)', 'File', 'Tool', 'Similarity'];
+        let rows = [];
+
+        for (let i = 0; i < pairKeys.length; i++) {
+            const pairKey = pairKeys[i];
             const pair = results[pairKey];
             const sims = pair['similarities'] ?? {};
             const fileNames = Object.keys(sims).sort();
 
             // Shorten pair key for display — keep only short IDs.
             const parts = pairKey.split('||');
-            const shortDisplay = parts.map((p) => {
+            const shortDisplay = parts.map(function(p) {
                 const segs = p.split('::');
                 return segs[segs.length - 1] ?? p;
             }).join(' || ');
 
+            const shortSpan = `<span title='${escapeHTML(pairKey)}'>${escapeHTML(shortDisplay)}</span>`;
+
             let pairHasRows = false;
-            for (const filename of fileNames) {
+            for (let j = 0; j < fileNames.length; j++) {
+                const filename = fileNames[j];
                 const toolEntries = sims[filename] ?? [];
-                for (const entry of toolEntries) {
-                    const score = entry['score'] ?? null;
-                    rows += `
-                        <tr>
-                            <td title='${escapeHTML(pairKey)}'>${escapeHTML(shortDisplay)}</td>
-                            <td>${escapeHTML(filename)}</td>
-                            <td>${escapeHTML(entry['tool'] ?? '-')}</td>
-                            <td>${similarityBar(score)}</td>
-                        </tr>
-                    `;
+                
+                for (let k = 0; k < toolEntries.length; k++) {
+                    const entry = toolEntries[k];
+                    rows.push([
+                        shortSpan,
+                        escapeHTML(filename),
+                        escapeHTML(entry['tool'] ?? '-'),
+                        similarityBar(entry['score'] ?? null)
+                    ]);
                     pairHasRows = true;
                 }
             }
 
             // Fallback: no files at all, OR files exist but all tool entry arrays were empty.
             if (!pairHasRows) {
-                rows += `
-                    <tr>
-                        <td title='${escapeHTML(pairKey)}'>${escapeHTML(shortDisplay)}</td>
-                        <td colspan='3'>${pendingState('No tool results available.')}</td>
-                    </tr>
-                `;
+                rows.push([
+                    shortSpan,
+                    pendingState('No tool results available.'),
+                    '-',
+                    '-'
+                ]);
             }
         }
 
-        pairsHTML = `
-            <table class='standard-table pairwise-pairs-table'>
-                <thead>
-                    <tr>
-                        <th>Pair (short IDs)</th>
-                        <th>File</th>
-                        <th>Tool</th>
-                        <th>Similarity</th>
-                    </tr>
-                </thead>
-                <tbody>${rows}</tbody>
-            </table>
-        `;
+        pairsHTML = tableFromLists(resHeaders, rows, ['pairwise-pairs-table']);
     }
 
     html += analysisSection('Per-Pair Comparisons', pairsHTML);
 
-    // --- Raw JSON Fallback ---
+    // Raw JSON fallback.
     html += rawJsonFallback(result);
 
     return html;
@@ -380,7 +326,7 @@ export {
     msToSeconds,
     scoreBar,
     similarityBar,
-    aggregateCells,
+    aggregateToRow,
     pendingState,
     analysisSection,
     rawJsonFallback,

--- a/site/js/modules/webui/render/analysis.js
+++ b/site/js/modules/webui/render/analysis.js
@@ -1,0 +1,389 @@
+// Shared render helpers for code analysis result visualizations.
+// Used by both individual.js and pairwise.js.
+
+// ─── Utility Helpers ────────────────────────────────────────────────────────
+
+function escapeHTML(str) {
+    if (str === null || str === undefined) {
+        return '';
+    }
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+function formatNumber(value, decimalPlaces = 2) {
+    if (value === null || value === undefined) {
+        return '-';
+    }
+    const num = Number(value);
+    if (!Number.isFinite(num)) {
+        return '-';
+    }
+    return num.toFixed(decimalPlaces);
+}
+
+function formatPercent(value) {
+    if (value === null || value === undefined) {
+        return '-';
+    }
+    return formatNumber(value * 100, 1) + '%';
+}
+
+function msToSeconds(ms) {
+    if (ms === null || ms === undefined) {
+        return '-';
+    }
+    return formatNumber(ms / 1000) + 's';
+}
+
+// ─── Visual Render Helpers ───────────────────────────────────────────────────
+
+// Renders a horizontal progress bar.
+// maxValue should come from summary aggregate max — never hardcoded.
+function scoreBar(value, maxValue) {
+    if (value === null || value === undefined || !maxValue || maxValue === 0) {
+        return `<span>-</span>`;
+    }
+    const pct = Math.min(100, (value / maxValue) * 100).toFixed(1);
+    return `
+        <div class='score-bar-container'>
+            <div class='score-bar-track'>
+                <div class='score-bar-fill' style='width:${pct}%'></div>
+            </div>
+            <span>${formatNumber(value)}</span>
+        </div>
+    `;
+}
+
+// Renders a colored similarity bar: green (low) / orange (mid) / red (high).
+function similarityBar(score) {
+    if (score === null || score === undefined) {
+        return `<span>-</span>`;
+    }
+    let cls = 'similarity-low';
+    if (score >= 0.5) {
+        cls = 'similarity-high';
+    } else if (score >= 0.2) {
+        cls = 'similarity-mid';
+    }
+    const pct = Math.min(100, score * 100).toFixed(1);
+    return `
+        <div class='score-bar-container'>
+            <div class='score-bar-track'>
+                <div class='score-bar-fill ${cls}' style='width:${pct}%'></div>
+            </div>
+            <span>${formatPercent(score)}</span>
+        </div>
+    `;
+}
+
+// Renders cells: count | mean | median | min | max from an aggregate object.
+function aggregateCells(aggregate) {
+    if (!aggregate) {
+        return `<td colspan='5'>-</td>`;
+    }
+    return `
+        <td>${formatNumber(aggregate['count'], 0)}</td>
+        <td>${formatNumber(aggregate['mean'])}</td>
+        <td>${formatNumber(aggregate['median'])}</td>
+        <td>${formatNumber(aggregate['min'])}</td>
+        <td>${formatNumber(aggregate['max'])}</td>
+    `;
+}
+
+// Returns styled pending/empty state paragraph.
+function pendingState(message = 'Data pending or unavailable.') {
+    return `<p class='analysis-pending'>${escapeHTML(message)}</p>`;
+}
+
+// Wraps content in a titled analysis section block.
+function analysisSection(title, bodyHTML) {
+    return `
+        <div class='analysis-section'>
+            <h3>${escapeHTML(title)}</h3>
+            ${bodyHTML}
+        </div>
+    `;
+}
+
+// Collapsible raw JSON fallback for debugging.
+function rawJsonFallback(result) {
+    const json = JSON.stringify(result, null, 4);
+    return `
+        <details class='raw-json-fallback'>
+            <summary>Raw JSON</summary>
+            <pre class='code-block'>${escapeHTML(json)}</pre>
+        </details>
+    `;
+}
+
+// ─── Individual Analysis Sections ────────────────────────────────────────────
+
+function renderIndividualAnalysis(result) {
+    const summary = result['summary'];
+    const results = result['results'] ?? {};
+    const isComplete = result['complete'];
+
+    let html = '';
+
+    // Pending banner.
+    if (!isComplete) {
+        html += `<p class='analysis-pending'>⏳ Analysis is still running. Showing partial data.</p>`;
+    }
+
+    // --- Section A: Summary Stats ---
+    const aggregateHeaders = `
+        <tr>
+            <th>Metric</th>
+            <th>Count</th>
+            <th>Mean</th>
+            <th>Median</th>
+            <th>Min</th>
+            <th>Max</th>
+        </tr>
+    `;
+
+    const summaryRows = [
+        ['Score',         summary['aggregate-score']],
+        ['Lines of Code', summary['aggregate-lines-of-code']],
+        ['Time Delta',    summary['aggregate-submission-time-delta']],
+        ['LOC Delta',     summary['aggregate-lines-of-code-delta']],
+        ['Score Delta',   summary['aggregate-score-delta']],
+        ['LOC / hr (Velocity)',   summary['aggregate-lines-of-code-per-hour']],
+        ['Score / hr (Velocity)', summary['aggregate-score-per-hour']],
+    ].map(([label, agg]) => `
+        <tr>
+            <th class='label'>${escapeHTML(label)}</th>
+            ${aggregateCells(agg)}
+        </tr>
+    `).join('');
+
+    let summaryHTML = `
+        <table class='standard-table analysis-summary-table'>
+            <thead>${aggregateHeaders}</thead>
+            <tbody>${summaryRows}</tbody>
+        </table>
+    `;
+
+    // Per-file LOC sub-table.
+    const locPerFile = summary['aggregate-lines-of-code-per-file'];
+    if (locPerFile) {
+        const fileRows = Object.keys(locPerFile).sort().map((filename) => `
+            <tr>
+                <td>${escapeHTML(filename)}</td>
+                ${aggregateCells(locPerFile[filename])}
+            </tr>
+        `).join('');
+
+        summaryHTML += `
+            <h4 style='margin-top:1em;margin-bottom:0.5em;'>Lines of Code per File</h4>
+            <table class='standard-table analysis-loc-per-file-table'>
+                <thead>
+                    <tr>
+                        <th>File</th><th>Count</th><th>Mean</th><th>Median</th><th>Min</th><th>Max</th>
+                    </tr>
+                </thead>
+                <tbody>${fileRows}</tbody>
+            </table>
+        `;
+    } else {
+        summaryHTML += pendingState('Per-file LOC breakdown not yet available.');
+    }
+
+    html += analysisSection('Summary Statistics', summaryHTML);
+
+    // --- Section B: Per-Submission Table ---
+    const dynamicMax = summary['aggregate-score']?.['max'] ?? 1;
+    const submissionIDs = Object.keys(results).sort();
+
+    let resultsHTML = '';
+    if (submissionIDs.length === 0) {
+        resultsHTML = pendingState('No individual results yet.');
+    } else {
+        const rows = submissionIDs.map((id) => {
+            const r = results[id];
+            const score      = r['score']                 ?? null;
+            const loc        = r['lines-of-code']         ?? null;
+            const timeDelta  = r['submission-time-delta'] ?? null;
+            const locDelta   = r['lines-of-code-delta']   ?? null;
+            const scoreDelta = r['score-delta']           ?? null;
+            const locPerHr   = r['lines-of-code-per-hour'] ?? null;
+            const scorePerHr = r['score-per-hour']        ?? null;
+
+            return `
+                <tr>
+                    <td title='${escapeHTML(id)}'>${escapeHTML(r['short-id'] ?? id)}</td>
+                    <td>${scoreBar(score, dynamicMax)}</td>
+                    <td>${formatNumber(loc, 0)}</td>
+                    <td>${msToSeconds(timeDelta)}</td>
+                    <td>${formatNumber(locDelta, 0)}</td>
+                    <td>${formatNumber(scoreDelta)}</td>
+                    <td>${formatNumber(locPerHr)}</td>
+                    <td>${formatNumber(scorePerHr)}</td>
+                </tr>
+            `;
+        }).join('');
+
+        resultsHTML = `
+            <table class='standard-table analysis-results-table'>
+                <thead>
+                    <tr>
+                        <th>Submission ID</th>
+                        <th>Score</th>
+                        <th>LOC</th>
+                        <th>Time Δ</th>
+                        <th>LOC Δ</th>
+                        <th>Score Δ</th>
+                        <th>LOC / hr</th>
+                        <th>Score / hr</th>
+                    </tr>
+                </thead>
+                <tbody>${rows}</tbody>
+            </table>
+        `;
+    }
+
+    html += analysisSection('Per-Submission Results', resultsHTML);
+
+    // --- Raw JSON Fallback ---
+    html += rawJsonFallback(result);
+
+    return html;
+}
+
+// ─── Pairwise Analysis Sections ──────────────────────────────────────────────
+
+function renderPairwiseAnalysis(result) {
+    const summary = result['summary'];
+    const results = result['results'] ?? {};
+    const isComplete = result['complete'];
+
+    let html = '';
+
+    if (!isComplete) {
+        html += `<p class='analysis-pending'>⏳ Analysis is still running. Showing partial data.</p>`;
+    }
+
+    // --- Section A: Summary ---
+    const totalMean = summary['aggregate-total-mean-similarity'];
+    let summaryHTML = `
+        <div style='margin-bottom:1em;'>
+            <strong>Overall Mean Similarity:</strong>
+            ${similarityBar(totalMean?.['mean'] ?? null)}
+        </div>
+    `;
+
+    const meanSims = summary['aggregate-mean-similarities'];
+    if (meanSims) {
+        const fileRows = Object.keys(meanSims).sort().map((filename) => `
+            <tr>
+                <td>${escapeHTML(filename)}</td>
+                ${aggregateCells(meanSims[filename])}
+            </tr>
+        `).join('');
+
+        summaryHTML += `
+            <table class='standard-table pairwise-summary'>
+                <thead>
+                    <tr>
+                        <th>File</th><th>Count</th><th>Mean</th><th>Median</th><th>Min</th><th>Max</th>
+                    </tr>
+                </thead>
+                <tbody>${fileRows}</tbody>
+            </table>
+        `;
+    } else {
+        summaryHTML += pendingState('Per-file similarity summary not yet available.');
+    }
+
+    html += analysisSection('Similarity Summary', summaryHTML);
+
+    // --- Section B: Per-Pair Flattened Table ---
+    const pairKeys = Object.keys(results).sort();
+    let pairsHTML = '';
+
+    if (pairKeys.length === 0) {
+        pairsHTML = pendingState('No pairwise results yet.');
+    } else {
+        let rows = '';
+        for (const pairKey of pairKeys) {
+            const pair = results[pairKey];
+            const sims = pair['similarities'] ?? {};
+            const fileNames = Object.keys(sims).sort();
+
+            // Shorten pair key for display — keep only short IDs.
+            const parts = pairKey.split('||');
+            const shortDisplay = parts.map((p) => {
+                const segs = p.split('::');
+                return segs[segs.length - 1] ?? p;
+            }).join(' || ');
+
+            let pairHasRows = false;
+            for (const filename of fileNames) {
+                const toolEntries = sims[filename] ?? [];
+                for (const entry of toolEntries) {
+                    const score = entry['score'] ?? null;
+                    rows += `
+                        <tr>
+                            <td title='${escapeHTML(pairKey)}'>${escapeHTML(shortDisplay)}</td>
+                            <td>${escapeHTML(filename)}</td>
+                            <td>${escapeHTML(entry['tool'] ?? '-')}</td>
+                            <td>${similarityBar(score)}</td>
+                        </tr>
+                    `;
+                    pairHasRows = true;
+                }
+            }
+
+            // Fallback: no files at all, OR files exist but all tool entry arrays were empty.
+            if (!pairHasRows) {
+                rows += `
+                    <tr>
+                        <td title='${escapeHTML(pairKey)}'>${escapeHTML(shortDisplay)}</td>
+                        <td colspan='3'>${pendingState('No tool results available.')}</td>
+                    </tr>
+                `;
+            }
+        }
+
+        pairsHTML = `
+            <table class='standard-table pairwise-pairs-table'>
+                <thead>
+                    <tr>
+                        <th>Pair (short IDs)</th>
+                        <th>File</th>
+                        <th>Tool</th>
+                        <th>Similarity</th>
+                    </tr>
+                </thead>
+                <tbody>${rows}</tbody>
+            </table>
+        `;
+    }
+
+    html += analysisSection('Per-Pair Comparisons', pairsHTML);
+
+    // --- Raw JSON Fallback ---
+    html += rawJsonFallback(result);
+
+    return html;
+}
+
+export {
+    escapeHTML,
+    formatNumber,
+    formatPercent,
+    msToSeconds,
+    scoreBar,
+    similarityBar,
+    aggregateCells,
+    pendingState,
+    analysisSection,
+    rawJsonFallback,
+    renderIndividualAnalysis,
+    renderPairwiseAnalysis,
+};

--- a/site/js/modules/webui/render/index.js
+++ b/site/js/modules/webui/render/index.js
@@ -1,3 +1,4 @@
+export * from './analysis.js';
 export * from './api.js';
 export * from './card.js';
 export * from './dom.js';

--- a/site/js/modules/webui/util/strings.js
+++ b/site/js/modules/webui/util/strings.js
@@ -29,6 +29,14 @@ function displayJSON(value) {
     return JSON.stringify(value, null, JSON_INDENT);
 }
 
+// Escape a string for safe insertion into HTML.
+function escapeHTML(str) {
+    if (str === null || str === undefined) {
+        return '';
+    }
+    return new Option(String(str)).innerHTML;
+}
+
 function stringCompare(a, b) {
     return a.localeCompare(b);
 }
@@ -54,6 +62,7 @@ export {
     caseInsensitiveStringCompare,
     cleanText,
     displayJSON,
+    escapeHTML,
     stringCompare,
     titleCase,
 }

--- a/site/js/modules/webui/util/strings.test.js
+++ b/site/js/modules/webui/util/strings.test.js
@@ -84,3 +84,33 @@ describe("titleCase() base", function() {
         expect(Strings.titleCase(input, clean)).toBe(expected);
     });
 });
+
+describe("escapeHTML() base", function() {
+    // [[input, expected], ...]
+    const testCases = [
+        // Null/undefined guard.
+        [null, ''],
+        [undefined, ''],
+
+        // Plain strings pass through unchanged.
+        ['', ''],
+        ['hello', 'hello'],
+
+        // HTML special characters are escaped.
+        ['<', '&lt;'],
+        ['>', '&gt;'],
+        ['&', '&amp;'],
+
+        // The Option trick does not escape double quotes,
+        // which is fine since attributes are not being constructed here.
+        ['"', '"'],
+
+        // Non-string coercion.
+        [42, '42'],
+        [true, 'true'],
+    ];
+
+    test.each(testCases)("'%s'", function(input, expected) {
+        expect(Strings.escapeHTML(input)).toBe(expected);
+    });
+});


### PR DESCRIPTION
## Description
This PR addresses [edulinq/autograder-server#142](https://github.com/edulinq/autograder-server/issues/142) by replacing the primary raw JSON analysis output in `autograder-web` with structured, visual tables and progress indicators for both Individual and Pairwise analysis pages.

## Changes Made
- **New shared render module**: `site/js/modules/webui/render/analysis.js`
  - Leverages standard `tableFromLists` for all table rendering to align with repo conventions.
  - Callbacks use standard `function()` blocks per `docs/development.md`.
  - Added shared helpers for:
    - HTML escaping and numeric/percentage/time formatting
    - Score bars with dynamic scaling
    - Similarity bars with threshold coloring
    - Pending/empty-state rendering
    - Collapsible raw JSON fallback rendering
- **Individual Analysis UI**
  - Replaced JSON-first output with:
    - Summary statistics table
    - `Lines of Code per File` breakdown (with null guard)
    - Per-submission results table with score visualization bars
  - Added clear pending state handling for incomplete analysis runs.
- **Pairwise Analysis UI**
  - Replaced JSON-first output with:
    - Overall mean similarity visual summary
    - Per-file aggregate similarity table
    - Flattened per-pair/per-file/per-tool similarity table
  - Added fallback handling for pairs that have files but empty tool-entry lists.
- **Styling**
  - Added analysis-specific styles in `site/css/style.css` for section layout, bars, pending states, and raw JSON details block.
- **Wiring**
  - Exported the new renderer via `site/js/modules/webui/render/index.js`.
  - Updated analysis route handlers to use new render functions.

## Testing
- Updated:
  - `site/js/modules/webui/courses/assignment/analysis/individual.test.js`
  - `site/js/modules/webui/courses/assignment/analysis/pairwise.test.js`
- Switched from raw JSON string checks to DOM-structure assertions (`querySelector`).
- Ran full test suite:
  - `npm test`
  - **Result: 123/123 tests passing**

## Screenshots

### Individual Analysis
<img width="2880" height="2964" alt="screencapture-localhost-8080-static-index-html-2026-04-02-02_18_43" src="https://github.com/user-attachments/assets/b588ebb3-77ed-4fe4-adee-1bb7da80e98f" />


### Pairwise Analysis
<img width="2880" height="2316" alt="screencapture-localhost-8080-static-index-html-2026-04-02-02_19_49" src="https://github.com/user-attachments/assets/479f9702-72fb-4f72-955b-0ca3f352c7f5" />


## Notes / Scope
- A true side-by-side code diff viewer is **not** included in this PR.
- Current pairwise analysis responses provide similarity scores, but not line/token match mappings needed for semantic diff visualization.

## Related Issue
Closes edulinq/autograder-server#142
